### PR TITLE
Fix declaration of `operator<<` for `PoDoFo::PdfString`

### DIFF
--- a/test/unit/StringTest.cpp
+++ b/test/unit/StringTest.cpp
@@ -29,9 +29,13 @@ using namespace PoDoFo;
 // Registers the fixture into the 'registry'
 CPPUNIT_TEST_SUITE_REGISTRATION( StringTest );
 
+namespace PoDoFo {
+
 inline std::ostream& operator<<(std::ostream& o, const PdfString& s)
 {
     return o << s.GetStringUtf8();
+}
+
 }
 
 void StringTest::setUp()


### PR DESCRIPTION
Since `PdfString` is in the `PoDoFo` namespace, the `operator<<` for it must be in the
same namespace as well, otherwise it is not found. In particular,
`operator<<(std::ostream&)` is needed by cppunit as a way to get the
string representation of an arbitrary type, when using
`CPPUNIT_ASSERT_EQUAL()` on instances of it.

This used to work with GCC until 11 because of a buggy behaviour.
GCC 12 fixed it [1], causing this test to fail to build with it.

[1] https://gcc.gnu.org/bugzilla/show_bug.cgi?id=51577