### PR TITLE
Enlarge CMAKE_MODULE_PATH instead of overwritting.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ include(GNUInstallDirs)
 set(CMAKE_CXX_STANDARD 17)
 
 # Load modules from our source tree too
-set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules" "${CMAKE_CURRENT_BINARY_DIR}")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules" "${CMAKE_CURRENT_BINARY_DIR}")
 
 # Builds must use this CMakeLists.txt, not the one in src/ or somewhere else.
 # If users try to use something else the results can be confusing. We set a


### PR DESCRIPTION
- [x] Accept to license the library and tools code under the terms
  of the [LGPL 2.0](https://spdx.org/licenses/LGPL-2.0-or-later.html) or later
- [x] Accept to license the library and tools code under the terms
  of the [MPL 2.0](https://spdx.org/licenses/MPL-2.0)
- [x] Accept to license the test code under the terms
  of the [MIT-0](https://spdx.org/licenses/MIT-0.html)
- [x] Checked coding [style](https://github.com/podofo/podofo/blob/master/CODING-STYLE.md)
- [x] The commits sequence is clean without work in progress/bugged revisions

Hello again.

This PR fixes minor issue when `PoDoFo` included into project as 3rdparty directory. In this case somebody in his `CMakeLists.txt` may do the following:

```cmake
set( PODOFO_BUILD_LIB_ONLY ON CACHE INTERNAL "" FORCE )
set( PODOFO_SHARED ON CACHE INTERNAL "" FORCE )
add_subdirectory( 3rdparty/podofo )
```
And if user builds his project with custom `CMAKE_MODULE_PATH` it will be overwritten in `3rdparty/podofo` and something can be not found. Whereas adding `"${CMAKE_MODULE_PATH}"` enlarges paths...