### PR TITLE
catch exceptions in podofotxtextract, as a good role model

### DIFF
--- a/tools/podofotxtextract/podofotxtextract.cpp
+++ b/tools/podofotxtextract/podofotxtextract.cpp
@@ -51,6 +51,16 @@ int main(int argc, char* argv[])
         e.PrintErrorMsg();
         return (int)e.GetCode();
     }
+    catch (std::range_error& e)
+    {
+        fprintf(stderr, "Error: A std::range_error(\"%s\") was thrown during processing the pdf file.\n", e.what());
+        return 127;
+    }
+    catch (std::runtime_error& e)
+    {
+        fprintf(stderr, "Error: A std::runtime_error(\"%s\") was thrown during processing the pdf file.\n", e.what());
+        return 127;
+    }
 
     return 0;
 }


### PR DESCRIPTION
Code using text extraction will need to catch and handle various exceptions to deal with broken PDF input files. Extend the example code to do that.

Example files running into these exceptions:
[G_without_g.pdf](https://github.com/podofo/podofo/files/10732560/G_without_g.pdf)
[unexpected_type.pdf](https://github.com/podofo/podofo/files/10732562/unexpected_type.pdf)
[bad_utf16.pdf](https://github.com/podofo/podofo/files/10732572/bad_utf16.pdf)


- [x] Accept to license the library and tools code under the terms
  of the [LGPL 2.0](https://spdx.org/licenses/LGPL-2.0-or-later.html) or later
- [x] Accept to license the library and tools code under the terms
  of the [MPL 2.0](https://spdx.org/licenses/MPL-2.0)
- [x] Accept to license the test code under the terms
  of the [MIT-0](https://spdx.org/licenses/MIT-0.html)
- [x] Read [contributions](https://github.com/podofo/podofo#contributions) guidelines
- [x] Checked coding [style](https://github.com/podofo/podofo/blob/master/CODING-STYLE.md)
- [x] The commits sequence is clean without work in progress/bugged revisions. In doubt, [squash](https://github.com/podofo/podofo/wiki/Squash-git-history-guide) the commits