### PR TITLE
avoid nullptr dereference in font metrics creation

### DIFF
--- a/src/podofo/main/PdfFontMetricsObject.cpp
+++ b/src/podofo/main/PdfFontMetricsObject.cpp
@@ -54,13 +54,20 @@ PdfFontMetricsObject::PdfFontMetricsObject(const PdfObject& font, const PdfObjec
             m_FontFileType = PdfFontFileType::Type3;
         }
 
-        if (descriptor == nullptr && m_FontFileType == PdfFontFileType::Type3)
+        if (descriptor == nullptr)
         {
-            if ((obj = font.GetDictionary().FindKey("Name")) != nullptr)
-                m_FontNameRaw = obj->GetName().GetString();
+            if (m_FontFileType == PdfFontFileType::Type3)
+            {
+                if ((obj = font.GetDictionary().FindKey("Name")) != nullptr)
+                    m_FontNameRaw = obj->GetName().GetString();
 
-            if ((obj = font.GetDictionary().FindKey("FontBBox")) != nullptr)
-                m_BBox = getBBox(*obj);
+                if ((obj = font.GetDictionary().FindKey("FontBBox")) != nullptr)
+                    m_BBox = getBBox(*obj);
+            }
+            else
+            {
+                PODOFO_RAISE_ERROR(PdfErrorCode::InvalidFontData);
+            }
         }
         else
         {


### PR DESCRIPTION
Example file used with `podofotxtextract`: [invalid_font.pdf](https://github.com/podofo/podofo/files/10732592/invalid_font.pdf)


- [x] Accept to license the library and tools code under the terms
  of the [LGPL 2.0](https://spdx.org/licenses/LGPL-2.0-or-later.html) or later
- [x] Accept to license the library and tools code under the terms
  of the [MPL 2.0](https://spdx.org/licenses/MPL-2.0)
- [x] Accept to license the test code under the terms
  of the [MIT-0](https://spdx.org/licenses/MIT-0.html)
- [x] Read [contributions](https://github.com/podofo/podofo#contributions) guidelines
- [x] Checked coding [style](https://github.com/podofo/podofo/blob/master/CODING-STYLE.md)
- [x] The commits sequence is clean without work in progress/bugged revisions. In doubt, [squash](https://github.com/podofo/podofo/wiki/Squash-git-history-guide) the commits