### PR TITLE
avoid nullptr dereference if trailer has not been loaded

### DIFF
--- a/src/podofo/main/PdfParser.cpp
+++ b/src/podofo/main/PdfParser.cpp
@@ -598,7 +598,9 @@ void PdfParser::ReadXRefStreamContents(InputStreamDevice& device, size_t offset,
 
 void PdfParser::ReadObjects(InputStreamDevice& device)
 {
-    PODOFO_ASSERT(m_Trailer != nullptr);
+    if (!m_Trailer) {
+        PODOFO_RAISE_ERROR(PdfErrorCode::NoTrailer);
+    }
     // Check for encryption and make sure that the encryption object
     // is loaded before all other objects
     PdfObject* encrypt = m_Trailer->GetDictionary().GetKey("Encrypt");

--- a/src/podofo/main/PdfParser.cpp
+++ b/src/podofo/main/PdfParser.cpp
@@ -598,7 +598,7 @@ void PdfParser::ReadXRefStreamContents(InputStreamDevice& device, size_t offset,
 
 void PdfParser::ReadObjects(InputStreamDevice& device)
 {
-    if (!m_Trailer) {
+    if (m_Trailer == nullptr) {
         PODOFO_RAISE_ERROR(PdfErrorCode::NoTrailer);
     }
     // Check for encryption and make sure that the encryption object


### PR DESCRIPTION
I am not sure claiming “no trailer” is the most useful error to throw here. But relying on an assertion seems just wrong when there is an input file we know triggers the case (cf. pull request #50, which kept the assertion in).

- [x] Accept to license the library and tools code under the terms
  of the [LGPL 2.0](https://spdx.org/licenses/LGPL-2.0-or-later.html) or later
- [x] Accept to license the library and tools code under the terms
  of the [MPL 2.0](https://spdx.org/licenses/MPL-2.0)
- [x] Accept to license the test code under the terms
  of the [MIT-0](https://spdx.org/licenses/MIT-0.html)
- [x] Read [contributions](https://github.com/podofo/podofo#contributions) guidelines
- [x] Checked coding [style](https://github.com/podofo/podofo/blob/master/CODING-STYLE.md)
- [x] The commits sequence is clean without work in progress/bugged revisions. In doubt, [squash](https://github.com/podofo/podofo/wiki/Squash-git-history-guide) the commits