### PR TITLE
Fix operator== for charbuff_t<> in C++20

### DIFF
--- a/src/podofo/auxiliary/basetypes.h
+++ b/src/podofo/auxiliary/basetypes.h
@@ -110,13 +110,13 @@ namespace PoDoFo
     template <typename = void>
     bool operator==(const charbuff_t<>& lhs, const std::string_view& rhs) noexcept
     {
-        return std::string_view{lhs} == rhs;
+        return std::string_view(lhs) == rhs;
     }
 
     template <typename = void>
     bool operator==(const std::string_view& lhs, const charbuff_t<>& rhs) noexcept
     {
-        return lhs == std::string_view{rhs};
+        return lhs == std::string_view(rhs);
     }
 
     template <typename = void>

--- a/src/podofo/auxiliary/basetypes.h
+++ b/src/podofo/auxiliary/basetypes.h
@@ -37,7 +37,7 @@ namespace PoDoFo
     class charbuff_t final : public std::string
     {
     public:
-        charbuff_t() { }
+        charbuff_t() noexcept { }
         charbuff_t(const charbuff_t&) = default;
         charbuff_t(charbuff_t&&) noexcept = default;
         charbuff_t(size_t size)
@@ -52,7 +52,6 @@ namespace PoDoFo
             : std::string(view) { }
         explicit charbuff_t(const std::string& str)
             : std::string(str) { }
-
     public:
         charbuff_t& operator=(const charbuff_t&) = default;
         charbuff_t& operator=(charbuff_t&&) noexcept = default;
@@ -71,7 +70,7 @@ namespace PoDoFo
             std::string::assign(view.data(), view.size());
             return *this;
         }
-        charbuff_t& operator=(std::string&& str)
+        charbuff_t& operator=(std::string&& str) noexcept
         {
             std::string::operator=(std::move(str));
             return *this;
@@ -87,49 +86,49 @@ namespace PoDoFo
     template <typename = void>
     bool operator==(const charbuff_t<>& lhs, const char* rhs)
     {
-        return std::operator==((std::string_view)lhs, rhs);
+        return static_cast<const std::string&>(lhs) == rhs;
     }
 
     template <typename = void>
     bool operator==(const char* lhs, const charbuff_t<>& rhs)
     {
-        return std::operator==(lhs, (std::string_view)rhs);
+        return lhs == static_cast<const std::string&>(rhs);
     }
 
     template <typename = void>
     bool operator==(const charbuff_t<>& lhs, const bufferview& rhs)
     {
-        return std::operator==((std::string_view)lhs, std::string_view(rhs.data(), rhs.size()));
+        return static_cast<const std::string&>(lhs) == std::string_view(rhs.data(), rhs.size());
     }
 
     template <typename = void>
     bool operator==(const bufferview& lhs, const charbuff_t<>& rhs)
     {
-        return std::operator==(std::string_view(lhs.data(), lhs.size()), (std::string_view)rhs);
+        return std::string_view(lhs.data(), lhs.size()) == static_cast<const std::string&>(rhs);
     }
 
     template <typename = void>
-    bool operator==(const charbuff_t<>& lhs, const std::string_view& rhs)
+    bool operator==(const charbuff_t<>& lhs, const std::string_view& rhs) noexcept
     {
-        return std::operator==((std::string_view)lhs, rhs);
+        return std::string_view{lhs} == rhs;
     }
 
     template <typename = void>
-    bool operator==(const std::string_view& lhs, const charbuff_t<>& rhs)
+    bool operator==(const std::string_view& lhs, const charbuff_t<>& rhs) noexcept
     {
-        return std::operator==(lhs, (std::string_view)rhs);
+        return lhs == std::string_view{rhs};
     }
 
     template <typename = void>
-    bool operator==(const charbuff_t<>& lhs, const std::string& rhs)
+    bool operator==(const charbuff_t<>& lhs, const std::string& rhs) noexcept
     {
-        return std::operator==((std::string)lhs, rhs);
+        return static_cast<const std::string&>(lhs) == rhs;
     }
 
     template <typename = void>
-    bool operator==(const std::string& lhs, const charbuff_t<>& rhs)
+    bool operator==(const std::string& lhs, const charbuff_t<>& rhs) noexcept
     {
-        return std::operator==(lhs, (std::string)rhs);
+        return lhs == static_cast<const std::string&>(rhs);
     }
 
     using charbuff = charbuff_t<>;


### PR DESCRIPTION
* Explicitly compare as `std::string_view`, `const std::string&`, or `const char*`
* Allow the compiler to figure out `operator==` instead of forcing `std::operator==` 
* Use static_cast instead of C-style casting (reinterpret_cast)
* Add noexcept where appropriate

Using gcc 13.1.1 on Arch Linux I get the following errors with this program:
```c++
#include <podofo/podofo.h>

int main() { return 0; }
```

```
g++ -std=c++20 test.cpp
In file included from /usr/include/podofo/auxiliary/StreamDevice.h:15,
                 from /usr/include/podofo/podofo.h:22,
                 from test.cpp:1:
/usr/include/podofo/auxiliary/basetypes.h: In function ‘bool PoDoFo::operator==(const char*, const charbuff_t<>&)’:
/usr/include/podofo/auxiliary/basetypes.h:96:31: error: no matching function for call to ‘operator==(const char*&, std::string_view)’
   96 |         return std::operator==(lhs, (std::string_view)rhs);
      |                ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/c++/13.1.1/iosfwd:42,
                 from /usr/include/c++/13.1.1/ios:40,
                 from /usr/include/c++/13.1.1/istream:40,
                 from /usr/include/podofo/auxiliary/InputDevice.h:10,
                 from /usr/include/podofo/podofo.h:19:
/usr/include/c++/13.1.1/bits/postypes.h:192:5: note: candidate: ‘template<class _StateT> bool std::operator==(const fpos<_StateT>&, const fpos<_StateT>&)’
  192 |     operator==(const fpos<_StateT>& __lhs, const fpos<_StateT>& __rhs)
      |     ^~~~~~~~
/usr/include/c++/13.1.1/bits/postypes.h:192:5: note:   template argument deduction/substitution failed:
/usr/include/podofo/auxiliary/basetypes.h:96:31: note:   mismatched types ‘const std::fpos<_StateT>’ and ‘const char*’
   96 |         return std::operator==(lhs, (std::string_view)rhs);
      |                ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/c++/13.1.1/string:43,
                 from /usr/include/c++/13.1.1/bits/locale_classes.h:40,
                 from /usr/include/c++/13.1.1/bits/ios_base.h:41,
                 from /usr/include/c++/13.1.1/ios:44:
/usr/include/c++/13.1.1/bits/allocator.h:237:5: note: candidate: ‘template<class _T1, class _T2> constexpr bool std::operator==(const allocator<_CharT>&, const allocator<_T2>&)’
  237 |     operator==(const allocator<_T1>&, const allocator<_T2>&)
      |     ^~~~~~~~
/usr/include/c++/13.1.1/bits/allocator.h:237:5: note:   template argument deduction/substitution failed:
/usr/include/podofo/auxiliary/basetypes.h:96:31: note:   mismatched types ‘const std::allocator<_CharT>’ and ‘const char*’
   96 |         return std::operator==(lhs, (std::string_view)rhs);
      |                ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
and on and on. It can't find a valid candidate for `std::operator==(const char*, std::string_view)`.

This doesn't happen with `-std=c++17`. It also doesn't happen when I use `clang++ -std=c++20 -stdlib=libc++ test.cpp`. I'm not exactly sure what the difference is, but I suspect it has something to do with explicitly using `std::operator==` instead of just `lhs == rhs` and maybe the introduction of the spaceship (`<=>`) operator in C++20.

If there was a specific reason to use `std::operator==` instead of just `==` I can redo my PR to use that by constructing a `std::string_view` from `const char*`.

- [x] Accept to license the library and tools code under the terms
  of the [LGPL 2.0](https://spdx.org/licenses/LGPL-2.0-or-later.html) or later
- [x] Accept to license the library and tools code under the terms
  of the [MPL 2.0](https://spdx.org/licenses/MPL-2.0)
- [x] Accept to license the test code under the terms
  of the [MIT-0](https://spdx.org/licenses/MIT-0.html)
- [x] Read [contributions](https://github.com/podofo/podofo#contributions) guidelines
- [x] Checked coding [style](https://github.com/podofo/podofo/blob/master/CODING-STYLE.md)
- [x] The commits sequence is clean without work in progress/bugged revisions. In doubt, [squash](https://github.com/podofo/podofo/wiki/Squash-git-history-guide) the commits