### PR TITLE
Speed up getPageNode

### DIFF
--- a/src/podofo/main/PdfName.cpp
+++ b/src/podofo/main/PdfName.cpp
@@ -31,6 +31,7 @@ const PdfName PdfName::KeySize = PdfName("Size");
 const PdfName PdfName::KeySubtype = PdfName("Subtype");
 const PdfName PdfName::KeyType = PdfName("Type");
 const PdfName PdfName::KeyFilter = PdfName("Filter");
+const PdfName PdfName::KeyParent = PdfName("Parent");
 
 PdfName::PdfName()
     : m_data(new NameData{ true, { }, nullptr })

--- a/src/podofo/main/PdfName.h
+++ b/src/podofo/main/PdfName.h
@@ -111,7 +111,7 @@ public:
 
     /** Default cast to raw data string view
      *
-     * It's used in PdfDictionary lookup 
+     * It's used in PdfDictionary lookup
      */
     operator std::string_view() const;
 
@@ -125,6 +125,7 @@ public:
     static const PdfName KeySubtype;
     static const PdfName KeyType;
     static const PdfName KeyFilter;
+    static const PdfName KeyParent;
 
 private:
     void expandUtf8String() const;

--- a/src/podofo/main/PdfPageCollection.cpp
+++ b/src/podofo/main/PdfPageCollection.cpp
@@ -181,6 +181,18 @@ PdfPage& PdfPageCollection::CreatePageAt(unsigned atIndex, const Rect& size)
     return *page;
 }
 
+void PdfPageCollection::CreatePagesAt(unsigned atIndex, const Rect& size, unsigned count) {
+    std::vector<PdfPage*> pages(count);
+    std::vector<PdfObject*> objects(count);
+    for (unsigned i = 0; i < count; i++)
+    {
+        pages[i] = new PdfPage(*GetRoot().GetDocument(), atIndex + i, size);
+        objects[i] = &pages[i]->GetObject();
+    }
+    InsertPagesAt(atIndex, objects);
+    for (unsigned i = 0; i < count; i++) m_cache.SetPage(atIndex + i, pages[i]);
+}
+
 void PdfPageCollection::AppendDocumentPages(const PdfDocument& doc)
 {
     return GetDocument().AppendDocumentPages(doc);

--- a/src/podofo/main/PdfPageCollection.h
+++ b/src/podofo/main/PdfPageCollection.h
@@ -138,7 +138,7 @@ private:
     PdfPage& getPage(unsigned index);
     PdfPage& getPage(const PdfReference& ref);
 
-    PdfObject* getPageNode(unsigned index, PdfObject& parent, PdfObjectList& parents);
+    PdfObject* getPageNode(unsigned index, PdfObject& parent, PdfObjectList& parents, bool useCache=true);
 
     unsigned getChildCount(const PdfObject& nodeObj) const;
 

--- a/src/podofo/main/PdfPageCollection.h
+++ b/src/podofo/main/PdfPageCollection.h
@@ -87,6 +87,15 @@ public:
      */
     PdfPage& CreatePageAt(unsigned atIndex, const Rect& size);
 
+    /** Create count new page objects and insert at the index atIndex. This is significantly faster
+     *  than calling CreatePageAt repeatedly.
+     *
+     *  \param size a Rect specifying the size of the page (i.e the /MediaBox key) in PDF units
+     *  \param atIndex index where to insert the new page (0-based)
+     *  \param count number of pages to create
+     */
+    void CreatePagesAt(unsigned atIndex, const Rect& size, unsigned count=1);
+
     /** Appends another PdfDocument to this document.
      *  \param doc the document to append
      */


### PR DESCRIPTION
Use the page cache when possible. The parents are found by resolving the /Parent keys, with some sanity checks. Has no API or ABI changes (only the signature of a private class method is changed).

Performance effect:

Merging 50 files:
Time with cache: 5.518844932084903
Time without cache: 8.605918841902167

Merging 100 files:
Time with cache: 27.879902871791273
Time without cache: 47.95755673595704

Merging 200 files:
Time with cache: 71.4067347201053
Time without cache: 149.95879156095907

Mostly fixes #85 though for best performance, a bulk API is needed.

- [x] Accept to license the library and tools code under the terms
  of the [LGPL 2.0](https://spdx.org/licenses/LGPL-2.0-or-later.html) or later
- [x] Accept to license the library and tools code under the terms
  of the [MPL 2.0](https://spdx.org/licenses/MPL-2.0)
- [x] Accept to license the test code under the terms
  of the [MIT-0](https://spdx.org/licenses/MIT-0.html)
- [x] Read [contributions](https://github.com/podofo/podofo#contributions) guidelines
- [x] Checked coding [style](https://github.com/podofo/podofo/blob/master/CODING-STYLE.md)
- [x] The commits sequence is clean without work in progress/bugged revisions. In doubt, [squash](https://github.com/podofo/podofo/wiki/Squash-git-history-guide) the commits