### PR TITLE
Fix issue #76 and add noexcept to from_chars function declaration to allow compilation on linux with clang14

### DIFF
--- a/src/podofo/main/PdfDocument.cpp
+++ b/src/podofo/main/PdfDocument.cpp
@@ -216,7 +216,7 @@ void PdfDocument::InsertDocumentPageAt(unsigned atIndex, const PdfDocument& doc,
     }
 
     // append all objects first and fix their references
-    for (auto& obj : GetObjects())
+    for (auto& obj : doc.GetObjects())
     {
         PdfReference ref(static_cast<uint32_t>(obj->GetIndirectReference().ObjectNumber() + difference), obj->GetIndirectReference().GenerationNumber());
         auto newObj = new PdfObject(PdfDictionary());

--- a/src/podofo/private/charconv_compat.h
+++ b/src/podofo/private/charconv_compat.h
@@ -32,7 +32,7 @@ namespace std
     // parameter since it may create mysterious
     // issues on clang
     inline from_chars_result from_chars(const char* first, const char* last,
-        double& value, chars_format fmt)
+        double& value, chars_format fmt) noexcept
     {
         auto ret = fast_float::from_chars(first, last, value, (fast_float::chars_format)fmt);
         return { ret.ptr, ret.ec };


### PR DESCRIPTION
- [x] Accept to license the library and tools code under the terms
  of the [LGPL 2.0](https://spdx.org/licenses/LGPL-2.0-or-later.html) or later
- [x] Accept to license the library and tools code under the terms
  of the [MPL 2.0](https://spdx.org/licenses/MPL-2.0)
- [x] Accept to license the test code under the terms
  of the [MIT-0](https://spdx.org/licenses/MIT-0.html)
- [x] Read [contributions](https://github.com/podofo/podofo#contributions) guidelines
- [x] Checked coding [style](https://github.com/podofo/podofo/blob/master/CODING-STYLE.md)
- [x] The commits sequence is clean without work in progress/bugged revisions. In doubt, [squash](https://github.com/podofo/podofo/wiki/Squash-git-history-guide) the commits

This is a fix for issue #76, along with a fix to allow compilation with clang14 on linux by adding noexcept to one of the functions (see the commit). The commits are separate in case you don't want one or the other.