### PR TITLE
Export PdfObjectInputStream and PdfObjectOutputStream with PODOFO_API

### DIFF
--- a/src/podofo/main/PdfObjectStream.h
+++ b/src/podofo/main/PdfObjectStream.h
@@ -20,7 +20,7 @@ namespace PoDoFo {
 class PdfObject;
 class PdfObjectStream;
 
-class PdfObjectInputStream : public InputStream
+class PODOFO_API PdfObjectInputStream : public InputStream
 {
     friend class PdfObjectStream;
 public:
@@ -44,7 +44,7 @@ private:
     std::vector<const PdfDictionary*> m_MediaDecodeParms;
 };
 
-class PdfObjectOutputStream : public OutputStream
+class PODOFO_API PdfObjectOutputStream : public OutputStream
 {
     friend class PdfObjectStream;
 public:


### PR DESCRIPTION
PdfObjectStream, a PODOFO_API exported class, has public methods GetInputStream and GetOutputStream returning PdfObjectInputStream and PdfObjectOutputStream instances. Consequently the caller code needs to be able to call the destructor of those classes, and their public methods. Currently there is a linking error related to that.

- [X] Accept to license the library and tools code under the terms
  of the [LGPL 2.0](https://spdx.org/licenses/LGPL-2.0-or-later.html) or later
- [X] Accept to license the library and tools code under the terms
  of the [MPL 2.0](https://spdx.org/licenses/MPL-2.0)
- [X] Accept to license the test code under the terms
  of the [MIT-0](https://spdx.org/licenses/MIT-0.html)
- [X] Read [contributions](https://github.com/podofo/podofo#contributions) guidelines
- [X] Checked coding [style](https://github.com/podofo/podofo/blob/master/CODING-STYLE.md)
- [X] The commits sequence is clean without work in progress/bugged revisions and merge commits. In doubt, [squash](https://github.com/podofo/podofo/wiki/Squash-git-history-guide) the commits and/or rebase master
