### PR TITLE
hotfixing nullptr exception while handling outlines during PdfDocumen…

### DIFF
--- a/src/podofo/main/PdfDocument.cpp
+++ b/src/podofo/main/PdfDocument.cpp
@@ -182,7 +182,7 @@ void PdfDocument::append(const PdfDocument& doc, bool appendAll)
         // append all outlines
         PdfOutlineItem* root = this->GetOutlines();
         PdfOutlines* appendRoot = const_cast<PdfDocument&>(doc).GetOutlines();
-        if (appendRoot && appendRoot->First())
+        if (root && appendRoot && appendRoot->First())
         {
             // only append outlines if appended document has outlines
             while (root && root->Next())


### PR DESCRIPTION
i had issues while trying to append a pdf to another. i could easily spot the root cause, but i'm far from beeing a pdf pro.

this hotfix worked for me, but please let me know if it needs more here.

…t::append.

- [x] Accept to license the library and tools code under the terms
  of the [LGPL 2.0](https://spdx.org/licenses/LGPL-2.0-or-later.html) or later
- [x] Accept to license the library and tools code under the terms
  of the [MPL 2.0](https://spdx.org/licenses/MPL-2.0)
- [x] Accept to license the test code under the terms
  of the [MIT-0](https://spdx.org/licenses/MIT-0.html)
- [x] Read [contributions](https://github.com/podofo/podofo#contributions) guidelines
- [x] Checked coding [style](https://github.com/podofo/podofo/blob/master/CODING-STYLE.md)
- [x] The commits sequence is clean without work in progress/bugged revisions and merge commits. In doubt, [squash](https://github.com/podofo/podofo/wiki/Squash-git-history-guide) the commits and/or rebase master
