### PR TITLE
fix compilation with libxml 2.12.0

### DIFF
--- a/src/podofo/main/PdfXMPPacket.cpp
+++ b/src/podofo/main/PdfXMPPacket.cpp
@@ -8,6 +8,7 @@
 #include "PdfXMPPacket.h"
 #include <podofo/private/XmlUtils.h>
 #include <libxml/xmlsave.h>
+#include <libxml/parser.h>
 #include <podofo/private/XMPUtils.h>
 
 using namespace std;

--- a/src/podofo/private/XmlUtils.h
+++ b/src/podofo/private/XmlUtils.h
@@ -8,6 +8,7 @@
 
 #include <string>
 #include <libxml/tree.h>
+#include <libxml/xmlerror.h>
 #include <podofo/auxiliary/nullable.h>
 
 // Cast macro that keep or enforce const to use
@@ -16,7 +17,7 @@
 
 #define THROW_LIBXML_EXCEPTION(msg)\
 {\
-    xmlErrorPtr error_ = xmlGetLastError();\
+    const xmlError* error_ = xmlGetLastError();\
     if (error_ == nullptr)\
         PODOFO_RAISE_ERROR_INFO(PdfErrorCode::XmpMetadata, msg);\
     else\


### PR DESCRIPTION
- [x] Accept to license the library and tools code under the terms
  of the [LGPL 2.0](https://spdx.org/licenses/LGPL-2.0-or-later.html) or later
- [x] Accept to license the library and tools code under the terms
  of the [MPL 2.0](https://spdx.org/licenses/MPL-2.0)
- [x] Accept to license the test code under the terms
  of the [MIT-0](https://spdx.org/licenses/MIT-0.html)
- [x] Read [contributions](https://github.com/podofo/podofo#contributions) guidelines
- [x] Checked coding [style](https://github.com/podofo/podofo/blob/master/CODING-STYLE.md)
- [x] The commits sequence is clean without work in progress/bugged revisions and merge commits. In doubt, [squash](https://github.com/podofo/podofo/wiki/Squash-git-history-guide) the commits and/or rebase master

fix #112 

_should_ be backwards compatible but I haven't tested it, so relying on the CI here.