### PR TITLE
Fix various typos

### DIFF
--- a/CODING-STYLE.md
+++ b/CODING-STYLE.md
@@ -1,7 +1,7 @@
 ## Coding style
 
 Coding style in PoDoFo follows the following general rules:
-- Visual Studio formatting conventions (see for example [C# convetions](https://docs.microsoft.com/en-us/dotnet/csharp/fundamentals/coding-style/coding-conventions)), where they apply to C/C++ like constructs;
+- Visual Studio formatting conventions (see for example [C# conventions](https://docs.microsoft.com/en-us/dotnet/csharp/fundamentals/coding-style/coding-conventions)), where they apply to C/C++ like constructs;
 - Capitalized case for **public** `MethodNames()`;
 - Camel case for variables, parameters and fields (example `variableName`);
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ CMake 3.16 and the following libraries:
 * libpng (optional)
 * libidn (optional)
 
-For the most polular toolchains, PoDoFo requires the following
+For the most popular toolchains, PoDoFo requires the following
 minimum versions:
 
 * msvc++ 14.16 (VS 2017 15.9)
@@ -61,7 +61,7 @@ PoDoFo tools are licensed under the [GPL 2.0](https://spdx.org/licenses/GPL-2.0-
 
 ## Development quickstart
 
-PoDoFo is known to compile through a multitude of package managers (including `apt-get`, [brew](https://brew.sh/), [vcpkg](https://vcpkg.io/), [Conan](https://conan.io/)), and has public continous integration working in [Ubuntu Linux](https://github.com/podofo/podofo/blob/master/.github/workflows/build-linux.yml), [MacOS](https://github.com/podofo/podofo/blob/master/.github/workflows/build-linux.yml) and
+PoDoFo is known to compile through a multitude of package managers (including `apt-get`, [brew](https://brew.sh/), [vcpkg](https://vcpkg.io/), [Conan](https://conan.io/)), and has public continuous integration working in [Ubuntu Linux](https://github.com/podofo/podofo/blob/master/.github/workflows/build-linux.yml), [MacOS](https://github.com/podofo/podofo/blob/master/.github/workflows/build-linux.yml) and
 [Windows](https://github.com/podofo/podofo/blob/master/.github/workflows/build-win.yml), bootstrapping the CMake project, building and testing the library. It's highly recommended to build PoDoFo using such package managers. 
 
 There's also a playground area in the repository where you can have
@@ -111,7 +111,7 @@ cmake --build . --config Debug
 ### Build with vcpkg
 
 Follow the vcpkg [quickstart](https://vcpkg.io/en/getting-started.html) guide to setup the package manager repository first.
-In Windows, it may be also useful to set the enviroment variable `VCPKG_DEFAULT_TRIPLET` to `x64-windows` to default installing 64 bit dependencies
+In Windows, it may be also useful to set the environment variable `VCPKG_DEFAULT_TRIPLET` to `x64-windows` to default installing 64 bit dependencies
 and define a `VCPKG_INSTALLATION_ROOT` variable with the location of the repository as created in the quickstart.
 
 Then from source root run:

--- a/TODO.md
+++ b/TODO.md
@@ -26,7 +26,7 @@
 - PdfPageCollection: Add iteration on PdfPage*. See PdfAnnotationCollection
 - PdfPageCollection::CreatePage() with PdfPageSize or default inferred from doc
 - PdfPage: Add GetFields() iteration
-- PdfDocument: Add GetAnnoationFields()/GetAllFields() iteration
+- PdfDocument: Add GetAnnotationFields()/GetAllFields() iteration
 - Fix PdfFontMetrics handling of symbol encoding
 - Fix/complete handling of text extraction in rotated pages
 - Check PdfWriter should really update doc trailer when saving.

--- a/examples/helloworld-base14/helloworld-base14.cpp
+++ b/examples/helloworld-base14/helloworld-base14.cpp
@@ -42,7 +42,7 @@ void HelloWorld(const string_view& filename)
     PdfPainter painter;
 
     // A PdfFont object is required to draw text on a PdfPage using a PdfPainter.
-    // PoDoFo will find the font using fontconfig on your system and embedd truetype
+    // PoDoFo will find the font using fontconfig on your system and embed truetype
     // fonts automatically in the PDF file.
     PdfFont* font;
 
@@ -60,7 +60,7 @@ void HelloWorld(const string_view& filename)
         // a nullptr pointer is returned.
         // We check for a nullptr pointer here and throw an exception using the RAISE_ERROR macro.
         // The raise error macro initializes a PdfError object with a given error code and
-        // the location in the file in which the error ocurred and throws it as an exception.
+        // the location in the file in which the error occurred and throws it as an exception.
 
         // Set the page as drawing target for the PdfPainter.
         // Before the painter can draw, a page has to be set first.
@@ -165,7 +165,7 @@ int main(int argc, char* argv[])
         return (int)err.GetCode();
     }
 
-    // The PDF was created sucessfully.
+    // The PDF was created successfully.
     std::cout << std::endl
         << "Created a PDF file containing the line \"Hello World!\": " << argv[1] << std::endl << std::endl;
 

--- a/examples/helloworld/helloworld.cpp
+++ b/examples/helloworld/helloworld.cpp
@@ -40,7 +40,7 @@ void HelloWorld(const string_view& filename)
     PdfPainter painter;
 
     // A PdfFont object is required to draw text on a PdfPage using a PdfPainter.
-    // PoDoFo will find the font using fontconfig on your system and embedd truetype
+    // PoDoFo will find the font using fontconfig on your system and embed truetype
     // fonts automatically in the PDF file.
     PdfFont* font;
 
@@ -158,7 +158,7 @@ int main(int argc, char* argv[])
     // back to the user.
     // 
     // All exceptions PoDoFo throws are objects of the class PdfError.
-    // Thats why we simply catch PdfError objects.
+    // That's why we simply catch PdfError objects.
     try
     {
         // Call the drawing routing which will create a PDF file
@@ -174,7 +174,7 @@ int main(int argc, char* argv[])
         return (int)err.GetCode();
     }
 
-    // The PDF was created sucessfully.
+    // The PDF was created successfully.
     cout << endl
         << "Created a PDF file containing the line \"Hello World!\": " << argv[1] << endl << endl;
 

--- a/playground/CMakeLists.txt
+++ b/playground/CMakeLists.txt
@@ -15,7 +15,7 @@ enable_testing() # Needed to enable "make test" from binary dir
 set(PODOFO_PLAYGROUND TRUE)
 
 if ("${ARCH}" STREQUAL "")
-    message(FATAL_ERROR "ARCH is not set. Run the boostrap scripts")
+    message(FATAL_ERROR "ARCH is not set. Run the bootstrap scripts")
 endif()
 
 if ("${PODOFO_DIR}" STREQUAL "")

--- a/playground/README.md
+++ b/playground/README.md
@@ -32,4 +32,4 @@ Playground dependencies are supplied only for PoDoFo development purposes and co
 with no warranty. They are not frequently updated, may contain security
 flaws and be unsafe to use. The dependencies directory layout is also
 optimized to be used by the `CMakeLists.txt` in this folder and it's
-not recommeded to use them in a different way.
+not recommended to use them in a different way.

--- a/src/podofo/auxiliary/OutputStream.h
+++ b/src/podofo/auxiliary/OutputStream.h
@@ -22,7 +22,7 @@ public:
 
     /** Write the character in the device
      *
-     *  \param ch the character to wrte
+     *  \param ch the character to write
      */
     void Write(char ch);
 

--- a/src/podofo/auxiliary/StreamDevice.cpp
+++ b/src/podofo/auxiliary/StreamDevice.cpp
@@ -160,7 +160,7 @@ StandardStreamDevice::StandardStreamDevice(iostream& stream)
 
     if (stream.tellp() != stream.tellg())
         PODOFO_RAISE_ERROR_INFO(PdfErrorCode::InvalidDeviceOperation,
-            "Unsupported mistmatch between read and read position in stream");
+            "Unsupported mismatch between read and read position in stream");
 }
 
 StandardStreamDevice::StandardStreamDevice(DeviceAccess access, ios& stream, bool streamOwned)

--- a/src/podofo/auxiliary/Version.h
+++ b/src/podofo/auxiliary/Version.h
@@ -1,7 +1,7 @@
 #ifndef PODOFO_VERSION_H
 #define PODOFO_VERSION_H
 
-// NOTE: Keep the relative import to accomodate
+// NOTE: Keep the relative import to accommodate
 // the installation layout
 #include "podofo_config.h"
 

--- a/src/podofo/auxiliary/nullable.h
+++ b/src/podofo/auxiliary/nullable.h
@@ -125,7 +125,7 @@ namespace PoDoFo
         T m_value;
     };
 
-    // Template spacialization for references
+    // Template specialization for references
     template <typename T>
     class nullable<T&> final
     {

--- a/src/podofo/main/PdfAcroForm.h
+++ b/src/podofo/main/PdfAcroForm.h
@@ -79,7 +79,7 @@ public:
      */
     void RemoveFieldAt(unsigned index);
 
-    /** Delete the field with the given object referece
+    /** Delete the field with the given object reference
      *  \param ref the object reference
      */
     void RemoveField(const PdfReference& ref);

--- a/src/podofo/main/PdfAction.h
+++ b/src/podofo/main/PdfAction.h
@@ -20,7 +20,7 @@ class PdfIndirectObjectList;
 
 /** The type of the action.
  *  PDF supports different action types, each of
- *  them has different keys and propeties.
+ *  them has different keys and properties.
  *
  *  Not all action types listed here are supported yet.
  *

--- a/src/podofo/main/PdfAnnotation.cpp
+++ b/src/podofo/main/PdfAnnotation.cpp
@@ -173,7 +173,7 @@ void PdfAnnotation::SetAppearanceStream(const PdfXObjectForm& xobj, PdfAppearanc
     double teta;
     if (MustGetPage().HasRotation(teta))
     {
-        // If the page has a rotation, add a preample object that
+        // If the page has a rotation, add a preamble object that
         // will transform the input xobject and adjust the orientation
         auto newMat = PoDoFo::GetFrameRotationTransform(xobj.GetRect(), -teta);
         auto actualXobj = GetDocument().CreateXObjectForm(xobj.GetRect());

--- a/src/podofo/main/PdfAnnotation.h
+++ b/src/podofo/main/PdfAnnotation.h
@@ -51,15 +51,15 @@ public:
     /** Set an appearance stream for this object
      *  to specify its visual appearance
      *  \param xobj an XObject form
-     *  \param appearance an apperance type to set
+     *  \param appearance an appearance type to set
      *  \param state the state for which set it the obj; states depend on the annotation type
      */
     void SetAppearanceStream(const PdfXObjectForm& xobj, PdfAppearanceType appearance = PdfAppearanceType::Normal, const PdfName& state = "");
 
     /** Set an appearance stream for this object
-     *  to specify its visual appearance withot handling page rotations
+     *  to specify its visual appearance without handling page rotations
      *  \param xobj an XObject form
-     *  \param appearance an apperance type to set
+     *  \param appearance an appearance type to set
      *  \param state the state for which set it the obj; states depend on the annotation type
      */
     void SetAppearanceStreamRaw(const PdfXObjectForm& xobj, PdfAppearanceType appearance = PdfAppearanceType::Normal, const PdfName& state = "");
@@ -74,7 +74,7 @@ public:
 
     /**
     * \returns the appearance stream for this object
-     *  \param appearance an apperance type to get
+     *  \param appearance an appearance type to get
      *  \param state a child state. Meaning depends on the annotation type
     */
     PdfObject* GetAppearanceStream(PdfAppearanceType appearance = PdfAppearanceType::Normal, const PdfName& state = "");
@@ -121,7 +121,7 @@ public:
     void SetBorderStyle(double hCorner, double vCorner, double width, const PdfArray& strokeStyle);
 
     /** Set the title of this annotation.
-     *  \param title title of the annoation as string in PDF format
+     *  \param title title of the annotation as string in PDF format
      *
      *  \see GetTitle
      */
@@ -137,7 +137,7 @@ public:
 
     /** Set the text of this annotation.
      *
-     *  \param contents text of the annoation as string in PDF format
+     *  \param contents text of the annotation as string in PDF format
      *
      *  \see GetContents
      */

--- a/src/podofo/main/PdfAnnotation_Types.h
+++ b/src/podofo/main/PdfAnnotation_Types.h
@@ -24,7 +24,7 @@ namespace PoDoFo {
     public:
         /** Get the quad points associated with the annotation (if appropriate).
          *  This array is used in text markup annotations to describe the
-         *  regions affected by the markup (i.e. the hilighted words, one
+         *  regions affected by the markup (i.e. the highlighted words, one
          *  quadrilateral per word)
          *
          *  \returns a PdfArray of 8xn numbers describing the
@@ -45,7 +45,7 @@ namespace PoDoFo {
 
         /** Set the quad points associated with the annotation (if appropriate).
          *  This array is used in text markup annotations to describe the
-         *  regions affected by the markup (i.e. the hilighted words, one
+         *  regions affected by the markup (i.e. the highlighted words, one
          *  quadrilateral per word)
          *
          *  \param quadPoints a PdfArray of 8xn numbers describing the
@@ -213,7 +213,7 @@ namespace PoDoFo {
         PdfAnnotationPopup(PdfPage& page, const Rect& rect);
         PdfAnnotationPopup(PdfObject& obj);
     public:
-        /** Sets whether this annotation is initialy open.
+        /** Sets whether this annotation is initially open.
          *  You should always set this true for popup annotations.
          *  \param b if true open it
          */
@@ -300,7 +300,7 @@ namespace PoDoFo {
         PdfAnnotationText(PdfPage& page, const Rect& rect);
         PdfAnnotationText(PdfObject& obj);
     public:
-        /** Sets whether this annotation is initialy open.
+        /** Sets whether this annotation is initially open.
          *  You should always set this true for popup annotations.
          *  \param b if true open it
          */

--- a/src/podofo/main/PdfArray.h
+++ b/src/podofo/main/PdfArray.h
@@ -182,7 +182,7 @@ public:
     /**
      * Resize the internal vector.
      * \param count new size
-     * \param value refernce value
+     * \param value reference value
      */
     void Resize(unsigned count, const PdfObject& val = PdfObject());
 

--- a/src/podofo/main/PdfCMapEncoding.cpp
+++ b/src/podofo/main/PdfCMapEncoding.cpp
@@ -116,8 +116,8 @@ PdfCharCodeMap parseCMapObject(const PdfObjectStream& stream, CodeLimits& limits
     //   /Supplement 0 def
     // >> def
     // which should be invalid Postscript (any language level). Adobe
-    // doesn't crash wich such CMap(s), but crashes if such syntax is
-    // used elsewere. Assuming the CMap(s) uses only PS Level 1, which
+    // doesn't crash with such CMap(s), but crashes if such syntax is
+    // used elsewhere. Assuming the CMap(s) uses only PS Level 1, which
     // doesn't, support << syntax, is a workaround to read these CMap(s)
     // without crashing.
     PdfPostScriptTokenizer tokenizer(PdfPostScriptLanguageLevel::L1);
@@ -323,7 +323,7 @@ void handleRangeMapping(PdfCharCodeMap& map,
         } while (it != end);
     }
 
-    // Compute new destination string with last chracter/code point incremented by one
+    // Compute new destination string with last character/code point incremented by one
     vector<char32_t> newdst;
     for (unsigned i = 0; i < rangeSize; i++)
     {
@@ -335,7 +335,7 @@ void handleRangeMapping(PdfCharCodeMap& map,
 }
 
 // codeSize is the number of the octets in the string or the minimum number
-// of bytes to represent the humber, example <cd> -> 1, <00cd> -> 2
+// of bytes to represent the number, example <cd> -> 1, <00cd> -> 2
 static uint32_t getCodeFromVariant(const PdfVariant& var, unsigned char& codeSize)
 {
     if (var.IsNumber())
@@ -415,9 +415,9 @@ vector<char32_t> handleUtf8String(const string& str)
 }
 
 // Read variant from a sequence, unless it's the end of it
-// We found Pdf(s) that have mistmatching sequence length and
+// We found Pdf(s) that have mismatching sequence length and
 // end of sequence marker, and Acrobat preflight treats them as valid,
-// so we must determine end of sequnce only on the end of
+// so we must determine end of sequence only on the end of
 // sequence keyword
 void readNextVariantSequence(PdfPostScriptTokenizer& tokenizer, InputStreamDevice& device,
     PdfVariant& variant, const string_view& endSequenceKeyword, bool& endOfSequence)

--- a/src/podofo/main/PdfCanvasInputDevice.cpp
+++ b/src/podofo/main/PdfCanvasInputDevice.cpp
@@ -118,7 +118,7 @@ size_t PdfCanvasInputDevice::readBuffer(char* buffer, size_t size, bool& eof)
                 return count;
         }
 
-        // Span reads into multple input devices
+        // Span reads into multiple input devices
         // NOTE: we ignore if the device reached EOF, and
         // we try pop another device at the next iteration
         read = device->Read(buffer + count, size, eof);
@@ -196,7 +196,7 @@ bool PdfCanvasInputDevice::tryGetNextDevice(InputStreamDevice*& device)
     return true;
 }
 
-// Returns true if one device was succesfully
+// Returns true if one device was successfully
 // popped out of the queue and is not EOF
 bool PdfCanvasInputDevice::tryPopNextDevice()
 {

--- a/src/podofo/main/PdfCatalog.cpp
+++ b/src/podofo/main/PdfCatalog.cpp
@@ -62,7 +62,7 @@ void PdfCatalog::SetMetadataStreamValue(const string_view& value)
     stream.SetData(value, true);
 
     // We are writing raw clear text, which is required in most
-    // relevant scenarions (eg. PDF/A). Remove any possibly
+    // relevant scenarios (eg. PDF/A). Remove any possibly
     // existing filter
     obj.GetDictionary().RemoveKey(PdfName::KeyFilter);
 

--- a/src/podofo/main/PdfCharCodeMap.h
+++ b/src/podofo/main/PdfCharCodeMap.h
@@ -12,7 +12,7 @@
 
 namespace PoDoFo
 {
-    /** A conventient typedef for an unspecified codepoint
+    /** A convenient typedef for an unspecified codepoint
      * The underlying type is convenientely char32_t so
      * it's a 32 bit fixed sized type that is also compatible
      * with unicode code points
@@ -52,7 +52,7 @@ namespace PoDoFo
         bool TryGetCodePoints(const PdfCharCode& codeUnit, std::vector<codepoint>& codePoints) const;
 
         /** Try get char code from utf8 encoded range
-         * \remarks It assumes it != and it will consumes the interator
+         * \remarks It assumes it != and it will consumes the iterator
          * also when returning false
          */
         bool TryGetNextCharCode(std::string_view::iterator& it,

--- a/src/podofo/main/PdfChoiceField.cpp
+++ b/src/podofo/main/PdfChoiceField.cpp
@@ -165,7 +165,7 @@ int PdChoiceField::GetSelectedIndex() const
         }
         else
         {
-            PODOFO_RAISE_ERROR_INFO(PdfErrorCode::InvalidDataType, "Choice field item has invaid data type");
+            PODOFO_RAISE_ERROR_INFO(PdfErrorCode::InvalidDataType, "Choice field item has invalid data type");
         }
     }
 

--- a/src/podofo/main/PdfColorSpace.h
+++ b/src/podofo/main/PdfColorSpace.h
@@ -156,7 +156,7 @@ namespace PoDoFo {
         static bool TryCreateFromObject(const PdfObject& obj, PdfColorSpacePtr& colorSpace);
 
         /** Singleton method which returns a global instance
-         *  of Uknown color space
+         *  of Unknown color space
          */
         static PdfColorSpacePtr GetUnkownInstance();
 

--- a/src/podofo/main/PdfContents.cpp
+++ b/src/podofo/main/PdfContents.cpp
@@ -102,7 +102,7 @@ PdfObjectStream & PdfContents::GetStreamForAppending(PdfStreamAppendFlags flags)
     if ((flags & PdfStreamAppendFlags::NoSaveRestorePrior) == PdfStreamAppendFlags::None)
     {
         // Record all content and readd into a new stream that
-        // substitue all the previous streams
+        // substitute all the previous streams
         charbuff buffer;
         BufferStreamDevice device(buffer);
         copyTo(device, *arr);
@@ -116,7 +116,7 @@ PdfObjectStream & PdfContents::GetStreamForAppending(PdfStreamAppendFlags flags)
             auto output = stream.GetOutputStream();
             output.Write("q\n");
             output.Write(buffer);
-            // TODO: Avoid adding unuseful \n prior Q
+            // TODO: Avoid adding useless \n prior Q
             output.Write("\nQ");
         }
     }

--- a/src/podofo/main/PdfDataContainer.h
+++ b/src/podofo/main/PdfDataContainer.h
@@ -27,7 +27,7 @@ protected:
     /** Create a new PdfDataOwnedType
      * Can only be called by subclasses
      * \remarks We don't define copy/move constructor as the
-     * the owner is not copied/movied
+     * the owner is not copied/moved
      */
     PdfDataContainer();
 

--- a/src/podofo/main/PdfDate.cpp
+++ b/src/podofo/main/PdfDate.cpp
@@ -17,10 +17,10 @@ using namespace PoDoFo;
 #define timegm _mkgmtime
 #endif
 
-// a PDF date has a maximum of 24 bytes incuding the terminating \0
+// a PDF date has a maximum of 24 bytes including the terminating \0
 #define PDF_DATE_BUFFER_SIZE 24
 
-// a W3C date has a maximum of 26 bytes incuding the terminating \0
+// a W3C date has a maximum of 26 bytes including the terminating \0
 #define W3C_DATE_BUFFER_SIZE 26
 
 #define PEEK_DATE_CHAR(str, zoneShift)\
@@ -399,7 +399,7 @@ chrono::seconds getSecondsFromEpoch()
     // Cast now() to seconds. We assume system_clock epoch is
     //  always 1970/1/1 UTC in all platforms, like in C++20
     auto now = chrono::time_point_cast<chrono::seconds>(chrono::system_clock::now());
-    // We forget about realtionship with UTC, convert to local seconds
+    // We forget about relationship with UTC, convert to local seconds
     return chrono::seconds(now.time_since_epoch());
 }
 

--- a/src/podofo/main/PdfDeclarations.h
+++ b/src/podofo/main/PdfDeclarations.h
@@ -373,7 +373,7 @@ enum class PdfStrokeStyle
 };
 
 /**
- * Enum to specifiy the initial information of the
+ * Enum to specify the initial information of the
  * info dictionary.
  */
 enum class PdfInfoInitial
@@ -531,7 +531,7 @@ enum class PdfStandard14FontType
 
 /** The type of the annotation.
  *  PDF supports different annotation types, each of
- *  them has different keys and propeties.
+ *  them has different keys and properties.
  *
  *  Not all annotation types listed here are supported yet.
  *

--- a/src/podofo/main/PdfDocument.h
+++ b/src/podofo/main/PdfDocument.h
@@ -74,7 +74,7 @@ public:
      *
      *  \param create create the object if it does not exist (ePdfCreateObject)
      *                 or return nullptr if it does not exist
-     *  \param eDefaultAppearance specifies if a default appearence shall be created
+     *  \param eDefaultAppearance specifies if a default appearance shall be created
      *
      *  \returns PdfObject the AcroForm dictionary
      */
@@ -101,7 +101,7 @@ public:
 
     void CollectGarbage();
 
-    /** Constuct a new PdfImage object
+    /** Construct a new PdfImage object
      *  \param prefix optional prefix for XObject-name
      */
     std::unique_ptr<PdfImage> CreateImage(const std::string_view& prefix = { });
@@ -288,7 +288,7 @@ protected:
     void Init();
 
     /** Clear all internal variables
-     *  and reset PdfDocument to an intial state.
+     *  and reset PdfDocument to an initial state.
      */
     void Clear();
 

--- a/src/podofo/main/PdfElement.h
+++ b/src/podofo/main/PdfElement.h
@@ -26,7 +26,7 @@ class PdfIndirectObjectList;
  *  a PdfObject and adds it to a vector of objects.
  *
  *  A PdfElement cannot be created directly. Use one
- *  of the subclasses which implement real functionallity.
+ *  of the subclasses which implement real functionality.
  *
  *  \see PdfPage \see PdfAction \see PdfAnnotation
  */

--- a/src/podofo/main/PdfEncoding.cpp
+++ b/src/podofo/main/PdfEncoding.cpp
@@ -329,7 +329,7 @@ void PdfEncoding::ExportToFont(PdfFont& font, PdfEncodingExportFlags flags) cons
         // if we are not subsetting. In that case we want a CID mapping
         if (font.IsSubsettingEnabled() || !tryExportObjectTo(fontDict, true))
         {
-            // If it doesn't have a name represenation, try to export a CID CMap
+            // If it doesn't have a name representation, try to export a CID CMap
             auto& cmapObj = fontDict.GetOwner()->GetDocument()->GetObjects().CreateDictionaryObject();
 
             // NOTE: Setting the CIDSystemInfo params in the CMap stream object is required
@@ -651,7 +651,7 @@ void PdfEncoding::writeCIDMapping(PdfObject& cmapObj, const PdfFont& font, const
 
 void PdfEncoding::writeToUnicodeCMap(PdfObject& cmapObj) const
 {
-    // NOTE: We definetely want a valid Unicode map at this point
+    // NOTE: We definitely want a valid Unicode map at this point
     charbuff temp;
     auto& toUnicode = GetToUnicodeMap();
     auto& stream = cmapObj.GetOrCreateStream();

--- a/src/podofo/main/PdfEncoding.h
+++ b/src/podofo/main/PdfEncoding.h
@@ -23,7 +23,7 @@ namespace PoDoFo
         SkipToUnicode = 1,  ///< Skip exporting a /ToUnicode entry
     };
 
-    /** A PDF string context to interatively scan a string
+    /** A PDF string context to iteratively scan a string
      * and collect both CID and unicode codepoints
      */
     class PODOFO_API PdfStringScanContext

--- a/src/podofo/main/PdfEncodingMap.h
+++ b/src/podofo/main/PdfEncodingMap.h
@@ -83,7 +83,7 @@ public:
      * predefined CMap names as well (ISO 32000-1:2008 Table 118
      * Predefined CJK CMap names, currently not implemented)
      * \remarks This is a low level information. Use PdfEncoding::IsSimpleEncoding()
-     * to dermine if the encoding is really a simple one
+     * to determine if the encoding is really a simple one
      */
     PdfEncodingMapType GetType() const { return m_Type; }
 
@@ -218,7 +218,7 @@ private:
 
 /**
  * PdfEncodingMap used by encodings like PdfBuiltInEncoding
- * or PdfDifferenceEncoding thats can define all their charset
+ * or PdfDifferenceEncoding that can define all their charset
  * with a single one byte range
  */
 class PODOFO_API PdfEncodingMapOneByte : public PdfEncodingMap

--- a/src/podofo/main/PdfEncrypt.cpp
+++ b/src/podofo/main/PdfEncrypt.cpp
@@ -1532,7 +1532,7 @@ void PdfEncryptSHABase::ComputeHash(const unsigned char* pswd, unsigned pswdLen,
             // CHECK-ME: The following was converted to new EVP_Encrypt API
             // from old internal API which is deprecated in OpenSSL 3.0 but
             // I'm not 100% sure the conversion is correct, since we don't
-            // finalize the context. It may be unecessary because of some
+            // finalize the context. It may be unnecessary because of some
             // preconditions, but these should be clearly stated
             rc = EVP_EncryptInit_ex(aes.get(), s_SSL.Aes128, nullptr, block, block + 16);
             rc = EVP_EncryptUpdate(aes.get(), data, &dataOutMoved, data, dataLen);

--- a/src/podofo/main/PdfError.h
+++ b/src/podofo/main/PdfError.h
@@ -50,7 +50,7 @@ enum class PdfErrorCode
     InvalidTrailerSize,       ///< The trailer size is invalid.
     InvalidDataType,          ///< The passed datatype is invalid or was not recognized
     InvalidXRef,              ///< The XRef table is invalid
-    InvalidXRefStream,        ///< A XRef steam is invalid
+    InvalidXRefStream,        ///< A XRef stream is invalid
     InvalidXRefType,          ///< The XRef type is invalid or was not found
     InvalidPredictor,         ///< Invalid or unimplemented predictor
     InvalidStrokeStyle,       ///< Invalid stroke style during drawing

--- a/src/podofo/main/PdfFileSpec.h
+++ b/src/podofo/main/PdfFileSpec.h
@@ -16,7 +16,7 @@ namespace PoDoFo {
 class PdfDocument;
 
 /**
- *  A file specification is used in the PDF file to referr to another file.
+ *  A file specification is used in the PDF file to refer to another file.
  *  The other file can be a file outside of the PDF or can be embedded into
  *  the PDF file itself.
  */
@@ -41,7 +41,7 @@ private:
 
     /** Initialize a filespecification from a filename
      *  \param filename filename
-     *  \param embed embedd the file data into the PDF file
+     *  \param embed embed the file data into the PDF file
      *  \param striPath whether to strip path from the file name string
      */
     void Init(const std::string_view& filename, bool embed, bool striPath);
@@ -60,9 +60,9 @@ private:
      */
     PdfString CreateFileSpecification(const std::string_view& filename) const;
 
-    /** Embedd a file into a stream object
+    /** Embed a file into a stream object
      *  \param obj write the file to this object stream
-     *  \param filename the file to embedd
+     *  \param filename the file to embed
      */
     void EmbeddFile(PdfObject& obj, const std::string_view& filename) const;
 

--- a/src/podofo/main/PdfFont.h
+++ b/src/podofo/main/PdfFont.h
@@ -187,7 +187,7 @@ public:
     double GetWordSpacingLength(const PdfTextState& state) const;
 
     /**
-     *  \remarks Doesn't throw if characater glyph could not be found
+     *  \remarks Doesn't throw if character glyph could not be found
      */
     double GetCharLength(char32_t codePoint, const PdfTextState& state, bool ignoreCharSpacing = false) const;
 
@@ -354,7 +354,7 @@ protected:
 
     virtual PdfObject* getDescendantFontObject();
 
-    /** Inititialization tasks for imported/created from scratch fonts
+    /** Initialization tasks for imported/created from scratch fonts
      */
     virtual void initImported();
 
@@ -371,7 +371,7 @@ private:
     void EmbedFont();
 
     /**
-     * Perform inititialization tasks for fonts imported or created
+     * Perform initialization tasks for fonts imported or created
      * from scratch
      */
     void InitImported(bool wantEmbed, bool wantSubset);

--- a/src/podofo/main/PdfFontCID.cpp
+++ b/src/podofo/main/PdfFontCID.cpp
@@ -161,7 +161,7 @@ void WidthExporter::update(unsigned cid, unsigned width)
 {
     if (cid == (m_start + m_rangeCount))
     {
-        // continous gid
+        // continuous gid
         if (width - m_width != 0)
         {
             // different width, so emit if previous range was with same width

--- a/src/podofo/main/PdfFontConfigWrapper.cpp
+++ b/src/podofo/main/PdfFontConfigWrapper.cpp
@@ -13,7 +13,7 @@ using namespace std;
 using namespace PoDoFo;
 
 #if defined(_WIN32) || defined(__ANDROID__) || defined(__APPLE__)
-// Windows, Android and Apple architectures don't primarly
+// Windows, Android and Apple architectures don't primarily
 // use fontconfig. We can supply a fallback configuration,
 // if a system configuration is not found
 #define HAS_FALLBACK_CONFIGURATION

--- a/src/podofo/main/PdfFontManager.cpp
+++ b/src/podofo/main/PdfFontManager.cpp
@@ -510,7 +510,7 @@ unique_ptr<charbuff> PdfFontManager::getWin32FontData(
 
     LOGFONTW lf{ };
     // NOTE: ANSI_CHARSET should give a consistent result among
-    // different locale configurations but sometimes dont' match fonts.
+    // different locale configurations but sometimes don't match fonts.
     // We prefer OEM_CHARSET over DEFAULT_CHARSET because it configures
     // the mapper in a way that will match more fonts
     lf.lfCharSet = OEM_CHARSET;
@@ -625,7 +625,7 @@ FT_Face getFontFaceFromBuffer(const bufferview& view, unsigned faceIndex, unique
 }
 
 // NOTE1: No check for collections
-// NOTE2: The function may be unsued depending on flags
+// NOTE2: The function may be unused depending on flags
 #pragma warning (suppress: 4505)
 FT_Face getFontFaceFromBuffer(const bufferview& view)
 {
@@ -711,7 +711,7 @@ Exit:
     return sucess;
 }
 
-// This function will recieve the device context for the
+// This function will receive the device context for the
 // TrueType Collection font, it will then extract necessary,
 // tables and create the correct buffer.
 void getFontDataTTC(charbuff& buffer, const charbuff& fileBuffer, const charbuff& ttcBuffer)

--- a/src/podofo/main/PdfFontManager.h
+++ b/src/podofo/main/PdfFontManager.h
@@ -45,7 +45,7 @@ struct PdfFontSearchParams
  *
  * PdfFont is an actual font that can be used in
  * a PDF file (i.e. it does also font embedding)
- * and PdfFontMetrics provides only metrics informations.
+ * and PdfFontMetrics provides only metrics information.
  *
  * \see PdfDocument
  */
@@ -135,8 +135,8 @@ private:
 
     /**
      * Empty the internal font cache.
-     * This should be done when ever a new document
-     * is created or openened.
+     * This should be done whenever a new document
+     * is created or opened.
      */
     void Clear();
 

--- a/src/podofo/main/PdfFontMetrics.h
+++ b/src/podofo/main/PdfFontMetrics.h
@@ -56,10 +56,10 @@ public:
     virtual bool TryGetGlyphWidth(unsigned gid, double& width) const = 0;
 
     /**
-     * Some fonts provides a glyph subsitution list, eg. for ligatures.
+     * Some fonts provides a glyph substitution list, eg. for ligatures.
      * OpenType fonts for example provides GSUB "Glyph Substitution Table"
-     * \param gids gids to be substituded
-     * \param backwardMap list of gid counts to remap back substituded gids
+     * \param gids gids to be substituted
+     * \param backwardMap list of gid counts to remap back substituted gids
      *     eg. { 32, 102, 105 } gets substituted in { 32, 174 }
      *     the backward map is { 1, 2 }
      */
@@ -72,7 +72,7 @@ public:
     virtual bool HasUnicodeMapping() const = 0;
 
     /** Try to retrieve the mapped gid from Unicode code point
-     * \remarks dont' use this method directly unless you know
+     * \remarks don't use this method directly unless you know
      * what you're doing: use PdfFont::TryGetGID instead
      */
     virtual bool TryGetGID(char32_t codePoint, unsigned& gid) const = 0;
@@ -199,7 +199,7 @@ public:
     virtual void GetBoundingBox(std::vector<double>& bbox) const = 0;
 
     /** Get the italic angle of this font.
-     *  Used to build the font dictionay
+     *  Used to build the font dictionary
      *  \returns the italic angle of this font.
      */
     virtual double GetItalicAngle() const = 0;
@@ -302,9 +302,9 @@ public:
     /** Create a best effort /ToUnicode map based on the
      * character unicode maps of the font
      *
-     * Thi is implemented just for PdfFontMetricsFreetype
+     * This is implemented just for PdfFontMetricsFreetype
      * This map may be unreliable because of ligatures,
-     * other kind of character subsitutions, or glyphs
+     * other kind of character substitutions, or glyphs
      * mapping to multiple unicode codepoints.
      */
     virtual std::unique_ptr<PdfCMapEncoding> CreateToUnicodeMap(const PdfEncodingLimits& limitHints) const;

--- a/src/podofo/main/PdfFontMetricsFreetype.cpp
+++ b/src/podofo/main/PdfFontMetricsFreetype.cpp
@@ -233,7 +233,7 @@ void PdfFontMetricsFreetype::ensureLengthsReady()
             m_Length1 = (unsigned)m_Data.view().size();
             break;
         default:
-            // Other font types dont't need lengths
+            // Other font types don't need lengths
             break;
     }
 

--- a/src/podofo/main/PdfFontMetricsObject.cpp
+++ b/src/podofo/main/PdfFontMetricsObject.cpp
@@ -313,7 +313,7 @@ PdfFontMetricsObject::PdfFontMetricsObject(const PdfObject& font, const PdfObjec
         m_MaxWidth = dict.FindKeyAs<double>("MaxWidth", -1) * m_Matrix[0];
     }
 
-    // Accorting to ISO 32000-1:2008, /FontName "shall be the
+    // According to ISO 32000-1:2008, /FontName "shall be the
     // same as the value of /BaseFont in the font or CIDFont
     // dictionary that refers to this font descriptor".
     // We prioritize /BaseFont, over /FontName

--- a/src/podofo/main/PdfFontTrueType.h
+++ b/src/podofo/main/PdfFontTrueType.h
@@ -14,7 +14,7 @@
 namespace PoDoFo {
 
 /** A PdfFont implementation that can be used
- *  to embedd truetype fonts into a PDF file
+ *  to embed truetype fonts into a PDF file
  *  or to draw with truetype fonts.
  *
  *  TrueType fonts are always embedded as suggested in the PDF reference.

--- a/src/podofo/main/PdfFontTrueTypeSubset.cpp
+++ b/src/podofo/main/PdfFontTrueTypeSubset.cpp
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: LGPL-2.0-or-later
  */
 
-// The code was initally based on work by ZhangYang
+// The code was initially based on work by ZhangYang
 // (张杨.国际) <zhang_yang@founder.com>
 
 #include <podofo/private/PdfDeclarationsPrivate.h>
@@ -498,7 +498,7 @@ void PdfFontTrueTypeSubset::WriteTables(string& buffer)
                 PODOFO_RAISE_ERROR_INFO(PdfErrorCode::InvalidEnumValue, "Unsupported table at this context");
         }
 
-        // Align the table length to 4 bytes and pad remaing space with zeroes
+        // Align the table length to 4 bytes and pad remaining space with zeroes
         size_t tableLength = output.GetPosition() - tableOffset;
         size_t tableLengthPadded = (tableLength + 3) & ~3;
         for (size_t i2 = tableLength; i2 < tableLengthPadded; i2++)

--- a/src/podofo/main/PdfFontTrueTypeSubset.h
+++ b/src/podofo/main/PdfFontTrueTypeSubset.h
@@ -42,7 +42,7 @@ public:
     /**
      * Actually generate the subsetted font
      * Create a new PdfFontTrueTypeSubset from an existing
-     * TTF font file retrived from a font metrics
+     * TTF font file retrieved from a font metrics
      *
      * \param output write the font to this buffer
      * \param metrics font metrics object for this font
@@ -101,7 +101,7 @@ private:
     {
         unsigned GlyfTableOffset = 0;
         unsigned LocaTableOffset = 0;
-        // Used internaly during recursive load
+        // Used internally during recursive load
         int16_t ContourCount = 0;
     };
 

--- a/src/podofo/main/PdfFontType1.cpp
+++ b/src/podofo/main/PdfFontType1.cpp
@@ -151,7 +151,7 @@ void PdfFontType1::embedFontSubset()
         (inBuff[inIndex + 5] << 24);				// little endian
     inIndex += 6;
 
-    // copy binary using encrpytion
+    // copy binary using encryption
     unsigned outIndexStart = outIndex;
     bool foundSeacGlyph;
 

--- a/src/podofo/main/PdfFontType1.h
+++ b/src/podofo/main/PdfFontType1.h
@@ -16,7 +16,7 @@
 namespace PoDoFo {
 
 /** A PdfFont implementation that can be used
- *  to embedd type1 fonts into a PDF file
+ *  to embed type1 fonts into a PDF file
  *  or to draw with type1 fonts.
  */
 class PdfFontType1 final : public PdfFontSimple

--- a/src/podofo/main/PdfFontType3.h
+++ b/src/podofo/main/PdfFontType3.h
@@ -14,7 +14,7 @@
 namespace PoDoFo {
 
 /** A PdfFont implementation that can be used
- *  to embedd type3 fonts into a PDF file
+ *  to embed type3 fonts into a PDF file
  *  or to draw with type3 fonts.
  *
  *  Type3 fonts are always embedded.

--- a/src/podofo/main/PdfIdentityEncoding.h
+++ b/src/podofo/main/PdfIdentityEncoding.h
@@ -17,8 +17,8 @@ namespace PoDoFo {
 enum class PdfIdentityOrientation
 {
     Unkwnown = 0,
-    Horizontal, // Corresponts to /Identity-H
-    Vertical,   // Corresponts to /Identity-V
+    Horizontal, // Corresponds to /Identity-H
+    Vertical,   // Corresponds to /Identity-V
 };
 
 /** PdfIdentityEncoding is a two-byte encoding which can be

--- a/src/podofo/main/PdfImage.cpp
+++ b/src/podofo/main/PdfImage.cpp
@@ -574,8 +574,8 @@ void PdfImage::loadFromJpegInfo(jpeg_decompress_struct& ctx, PdfImageInfo& info)
         {
             info.ColorSpace = PdfColorSpaceFactory::GetDeviceCMYKInstace();
 
-            // The jpeg-doc ist not specific in this point, but cmyk's seem to be stored
-            // in a inverted fashion. Fix by attaching a decode array
+            // The jpeg-doc isn't specific on this point, but cmyk's seem to be stored
+            // in an inverted fashion. Fix by attaching a decode array
             info.DecodeArray.push_back(1.0);
             info.DecodeArray.push_back(0.0);
             info.DecodeArray.push_back(1.0);

--- a/src/podofo/main/PdfImage.h
+++ b/src/podofo/main/PdfImage.h
@@ -31,7 +31,7 @@ struct PdfImageInfo
     std::vector<double> DecodeArray;
 };
 
-/** A PdfImage object is needed when ever you want to embedd an image
+/** A PdfImage object is needed when ever you want to embed an image
  *  file into a PDF document.
  *  The PdfImage object is embedded once and can be drawn as often
  *  as you want on any page in the document using PdfPainter
@@ -45,7 +45,7 @@ class PODOFO_API PdfImage final : public PdfXObject
     friend class PdfDocument;
 
 private:
-    /** Constuct a new PdfImage object
+    /** Construct a new PdfImage object
      *  This is an overloaded constructor.
      *
      *  \param parent parent document

--- a/src/podofo/main/PdfImmediateWriter.cpp
+++ b/src/podofo/main/PdfImmediateWriter.cpp
@@ -42,7 +42,7 @@ PdfImmediateWriter::PdfImmediateWriter(PdfIndirectObjectList& objects, const Pdf
     this->SetSaveOptions(opts);
     this->WritePdfHeader(*m_Device);
 
-    // Manually preapare the cross-reference table/stream
+    // Manually prepare the cross-reference table/stream
     m_xRef.reset(GetUseXRefStream() ? new PdfXRefStream(*this) : new PdfXRef(*this));
 }
 

--- a/src/podofo/main/PdfIndirectObjectList.cpp
+++ b/src/podofo/main/PdfIndirectObjectList.cpp
@@ -270,7 +270,7 @@ int32_t PdfIndirectObjectList::tryAddFreeObject(uint32_t objnum, uint32_t gennum
     // Documentation 3.4.3 Cross-Reference Table states: "The maximum
     // generation number is 65535; when a cross reference entry reaches
     // this value, it is never reused."
-    // NOTE: gennum is uint32 to accomodate overflows from callers
+    // NOTE: gennum is uint32 to accommodate overflows from callers
     if (gennum >= MaxXRefGenerationNum)
     {
         m_unavailableObjects.insert(gennum);

--- a/src/podofo/main/PdfIndirectObjectList.h
+++ b/src/podofo/main/PdfIndirectObjectList.h
@@ -275,7 +275,7 @@ private:
      *  Add the object only if the generation is the allowed range
      *
      *  \param rReference the reference to reuse
-     *  \returns true if the object was succesfully added
+     *  \returns true if the object was successfully added
      *
      *  \see AddFreeObject
      */

--- a/src/podofo/main/PdfInfo.h
+++ b/src/podofo/main/PdfInfo.h
@@ -33,7 +33,7 @@ public:
      *  object in the PDF file.
      *  \param obj must be an info dictionary.
      *  \param initial which information should be
-     *         writting initially to the information
+     *         writing initially to the information
      */
     PdfInfo(PdfObject& obj, PdfInfoInitial initial);
 
@@ -125,7 +125,7 @@ public:
 private:
     /** Add the initial document information to the dictionary.
      *  \param initial which information should be
-     *         writting initially to the information
+     *         writing initially to the information
      */
     void init(PdfInfoInitial initial);
 

--- a/src/podofo/main/PdfMath.h
+++ b/src/podofo/main/PdfMath.h
@@ -16,12 +16,12 @@ namespace PoDoFo
     class PdfPage;
 
     /**
-     * Get a rotation trasformation that aligns the rectangle to the axis after the rotation
+     * Get a rotation transformation that aligns the rectangle to the axis after the rotation
      */
     Matrix PODOFO_API GetFrameRotationTransform(const Rect& rect, double teta);
 
     /**
-     * Get an inverse rotation trasformation that aligns the rectangle to the axis after the rotation
+     * Get an inverse rotation transformation that aligns the rectangle to the axis after the rotation
      */
     Matrix PODOFO_API GetFrameRotationTransformInverse(const Rect& rect, double teta);
 

--- a/src/podofo/main/PdfMemDocument.h
+++ b/src/podofo/main/PdfMemDocument.h
@@ -21,7 +21,7 @@ class PdfWriter;
  *  PDF files and writing them back to disk.
  *
  *  PdfMemDocument was designed to allow easy access to the object
- *  structur of a PDF file.
+ *  structure of a PDF file.
  *
  *  PdfMemDocument should be used whenever you want to change
  *  the object structure of a PDF file.

--- a/src/podofo/main/PdfMetadata.h
+++ b/src/podofo/main/PdfMetadata.h
@@ -150,7 +150,7 @@ namespace PoDoFo
 
         /** Ensure the XMP metadata is created
          * Also, ensure some /Info metadata is normalized
-         * so it will be compatible with the corrispondent XMP
+         * so it will be compatible with the correspondent XMP
          */
         void EnsureXMPMetadata();
 

--- a/src/podofo/main/PdfNameTree.h
+++ b/src/podofo/main/PdfNameTree.h
@@ -86,7 +86,7 @@ public:
     void ToDictionary(const PdfName& dictionary, PdfDictionary& dict);
 
     /**
-     * I have made it for access to "JavaScript" dictonary. This is "document-level javascript storage"
+     * I have made it for access to "JavaScript" dictionary. This is "document-level javascript storage"
      *  \param create if true the javascript node is created if it does not exists.
      */
     PdfObject* GetJavaScriptNode(bool create = false) const;

--- a/src/podofo/main/PdfObject.cpp
+++ b/src/podofo/main/PdfObject.cpp
@@ -98,7 +98,7 @@ PdfObject::PdfObject(PdfDictionary&& dict) noexcept
     m_Variant.GetDictionaryUnsafe().SetOwner(*this);
 }
 
-// NOTE: Don't copy parent document/container/indirect refernce.
+// NOTE: Don't copy parent document/container/indirect reference.
 // Copied objects must be always detached. Ownership will be set
 // automatically elsewhere
 PdfObject::PdfObject(const PdfObject& rhs)
@@ -420,7 +420,7 @@ void PdfObject::EnableDelayedLoadingStream()
 void PdfObject::DelayedLoadStreamImpl()
 {
     // Default implementation throws, since delayed loading of
-    // steams should not be enabled except by types that support it.
+    // streams should not be enabled except by types that support it.
     PODOFO_RAISE_ERROR(PdfErrorCode::InternalLogic);
 }
 
@@ -509,7 +509,7 @@ void PdfObject::SetDirty()
     else if (m_Parent != nullptr)
     {
         // Reset parent if not indirect. Resetting will stop at
-        // first indirect anchestor
+        // first indirect ancestor
         m_Parent->SetDirty();
     }
 }

--- a/src/podofo/main/PdfObject.h
+++ b/src/podofo/main/PdfObject.h
@@ -203,7 +203,7 @@ public:
 
     /** Get the value of the object as int64_t
      *
-     *  This method throws if the numer is a floating point number
+     *  This method throws if the number is a floating point number
      *  \return the value of the number
      */
     int64_t GetNumber() const;
@@ -219,7 +219,7 @@ public:
 
     /** Get the value of the object as floating point number
      *
-     *  This method throws if the numer is integer
+     *  This method throws if the number is integer
      *  \return the value of the number
      */
     double GetRealStrict() const;

--- a/src/podofo/main/PdfOutlines.h
+++ b/src/podofo/main/PdfOutlines.h
@@ -21,7 +21,7 @@ class PdfIndirectObjectList;
 
 /**
  * The title of an outline item can be displayed
- * in different formating styles since PDF 1.4.
+ * in different formatting styles since PDF 1.4.
  */
 enum class PdfOutlineFormat
 {
@@ -205,7 +205,7 @@ protected:
      *  \param title title of this item
      *  \param dest destination of this item
      *  \param parentOutline parent of this outline item
-     *                        in the outline item hierarchie
+     *                        in the outline item hierarchy
      *  \param parent parent vector of objects which is required
      *                 to create new objects
      */
@@ -216,7 +216,7 @@ protected:
      *  \param title title of this item
      *  \param action action of this item
      *  \param parentOutline parent of this outline item
-     *                        in the outline item hierarchie
+     *                        in the outline item hierarchy
      *  \param parent parent vector of objects which is required
      *                 to create new objects
      */
@@ -226,7 +226,7 @@ protected:
     /** Create a PdfOutlineItem from an existing PdfObject
      *  \param obj an existing outline item
      *  \param parentOutline parent of this outline item
-     *                        in the outline item hierarchie
+     *                        in the outline item hierarchy
      *  \param previous previous item of this item
      */
     PdfOutlineItem(PdfObject& obj, PdfOutlineItem* parentOutline, PdfOutlineItem* previous);

--- a/src/podofo/main/PdfPageCollection.h
+++ b/src/podofo/main/PdfPageCollection.h
@@ -120,7 +120,7 @@ public:
      *
      *   \param atIndex the page number (0-based) to be removed
      *
-     *   The PdfPage object refering to this page will be deleted by this call!
+     *   The PdfPage object referring to this page will be deleted by this call!
      *   Empty page nodes will also be deleted.
      *
      *   \see PdfMemDocument::DeletePages

--- a/src/podofo/main/PdfPage_TextExtraction.cpp
+++ b/src/podofo/main/PdfPage_TextExtraction.cpp
@@ -596,7 +596,7 @@ void addEntryChunk(vector<PdfTextEntry> &textEntries, StringChunkList &chunks, c
                     if (lowerIndex != 0)
                     {
                         // Compute substring translation and apply it
-                        // TODO: Handle vertical scritps
+                        // TODO: Handle vertical scripts
                         double substringTx = computeLength(strings, glyphAddresses, 0, lowerIndex - 1);
                         textState.T_rm.Apply<Tx>(substringTx);
                     }
@@ -935,7 +935,7 @@ void ExtractionContext::PushString(const StatefulString &str, bool pushchunk)
     PODOFO_ASSERT(str.String.length() != 0);
     if (std::isnan(CurrentEntryT_rm_y))
     {
-        // Initalize tracking for line
+        // Initialize tracking for line
         CurrentEntryT_rm_y = States.Current->T_rm.Get<Ty>();
     }
 
@@ -1260,7 +1260,7 @@ void processChunks(const StringChunkList& chunks, string& destString,
     }
 }
 
-// TODO: Handle vertical scritps
+// TODO: Handle vertical scripts
 double computeLength(const vector<const StatefulString*>& strings, const vector<GlyphAddress>& glyphAddresses,
     unsigned lowerIndex, unsigned upperIndex)
 {
@@ -1343,7 +1343,7 @@ Rect computeBoundingBox(const TextState& textState, double boxWidth)
     // NOTE: This is very inaccurate
     // TODO1: Handle multiple text/pdf states
     // TODO2: Handle actual font glyphs (HARD)
-    // TODO3: Handle vertical scritps
+    // TODO3: Handle vertical scripts
     double descend = 0;
     double ascent = 0;
     auto& pdfState = textState.PdfState;

--- a/src/podofo/main/PdfPainter.h
+++ b/src/podofo/main/PdfPainter.h
@@ -68,7 +68,7 @@ struct PODOFO_API PdfDrawTextMultiLineParams final
 struct PODOFO_API PdfPainterState final
 {
     PdfGraphicsState GraphicsState;
-    PdfTextState TextState;         ///< The current sematical text state
+    PdfTextState TextState;         ///< The current semantical text state
     nullable<Vector2> FirstPoint;
     nullable<Vector2> CurrentPoint;
 private:

--- a/src/podofo/main/PdfPainterPath.h
+++ b/src/podofo/main/PdfPainterPath.h
@@ -145,12 +145,12 @@ public:
     std::string_view GetContent() const;
 
     /**
-     * Get the coordiantes of the first point
+     * Get the coordinates of the first point
      */
     const Vector2& GetFirstPoint() const;
 
     /**
-     * Get the coordiantes of the current point
+     * Get the coordinates of the current point
      */
     const Vector2& GetCurrentPoint() const;
 

--- a/src/podofo/main/PdfParser.cpp
+++ b/src/podofo/main/PdfParser.cpp
@@ -179,7 +179,7 @@ bool PdfParser::IsPdfFile(InputStreamDevice& device)
         return false;
 
     m_magicOffset = device.GetPosition() - PDF_MAGIC_LENGHT;
-    // try to determine the excact PDF version of the file
+    // try to determine the exact PDF version of the file
     m_PdfVersion = PoDoFo::GetPdfVersion(string_view(versionStr, std::size(versionStr)));
     if (m_PdfVersion == PdfVersion::Unknown)
         return false;
@@ -484,7 +484,7 @@ void PdfParser::ReadXRefSubsection(InputStreamDevice& device, int64_t& firstObje
                 &variant, &generation, &chType, &empty1, &empty2);
 
             if (!CheckXRefEntryType(chType))
-                PODOFO_RAISE_ERROR_INFO(PdfErrorCode::InvalidXRef, "Invalid used keyword, must be eiter 'n' or 'f'");
+                PODOFO_RAISE_ERROR_INFO(PdfErrorCode::InvalidXRef, "Invalid used keyword, must be either 'n' or 'f'");
 
             XRefEntryType type = XRefEntryTypeFromChar(chType);
 
@@ -517,7 +517,7 @@ void PdfParser::ReadXRefSubsection(InputStreamDevice& device, int64_t& firstObje
                 }
                 default:
                 {
-                    // This flow should have beeb alredy been cathed earlier
+                    // This flow should have beeb already been cathed earlier
                     PODOFO_ASSERT(false);
                 }
             }
@@ -768,7 +768,7 @@ void PdfParser::readObjectsInternal(InputStreamDevice& device)
         }
         // the linked free list in the xref section is not always correct in pdf's
         // (especially Illustrator) but Acrobat still accepts them. I've seen XRefs 
-        // where some object-numbers are alltogether missing and multiple XRefs where 
+        // where some object-numbers are altogether missing and multiple XRefs where 
         // the link list is broken.
         // Because PdfIndirectObjectList relies on a unbroken range, fill the free list more
         // robustly from all places which are either free or unparsed

--- a/src/podofo/main/PdfParserObject.cpp
+++ b/src/podofo/main/PdfParserObject.cpp
@@ -184,7 +184,7 @@ void PdfParserObject::parseStream()
         {
             // Skip spaces between the stream keyword and the carriage return/line
             // feed or line feed. Actually, this is not required by PDF Reference,
-            // but certain PDFs have additionals whitespaces
+            // but certain PDFs have additional whitespaces
             case ' ':
             case '\t':
                 (void)m_device->ReadChar();

--- a/src/podofo/main/PdfPostScriptTokenizer.cpp
+++ b/src/podofo/main/PdfPostScriptTokenizer.cpp
@@ -57,7 +57,7 @@ bool PdfPostScriptTokenizer::TryReadNext(InputStreamDevice& device, PdfPostScrip
 
     PdfLiteralDataType dataType = DetermineDataType(device, token, tokenType, variant);
 
-    // asume we read a variant unless we discover otherwise later.
+    // assume we read a variant unless we discover otherwise later.
     psTokenType = PdfPostScriptTokenType::Variant;
     switch (dataType)
     {

--- a/src/podofo/main/PdfSigner.cpp
+++ b/src/podofo/main/PdfSigner.cpp
@@ -58,7 +58,7 @@ void PoDoFo::SignDocument(PdfMemDocument& doc, StreamDevice& device, PdfSigner& 
     {
         // NOTE: Adobe is crazy and if the /NeedAppearances is set to true,
         // it will not show up the signature upon signing. Just
-        // remore the key just in case it's present (defaults to false)
+        // remove the key just in case it's present (defaults to false)
         acroForm->GetDictionary().RemoveKey("NeedAppearances");
     }
 

--- a/src/podofo/main/PdfString.cpp
+++ b/src/podofo/main/PdfString.cpp
@@ -116,7 +116,7 @@ void PdfString::Write(OutputStream& device, PdfWriteFlags writeMode,
     const PdfStatefulEncrypt& encrypt, charbuff& buffer) const
 {
     (void)writeMode;
-    (void)buffer; // TODO: Just use the supplied buffer istead of the many ones below
+    (void)buffer; // TODO: Just use the supplied buffer instead of the many ones below
 
     // Strings in PDF documents may contain \0 especially if they are encrypted
     // this case has to be handled!

--- a/src/podofo/main/PdfStringStream.h
+++ b/src/podofo/main/PdfStringStream.h
@@ -13,7 +13,7 @@
 namespace PoDoFo
 {
     /** A specialized Pdf output string stream
-     * It suplies an iostream-like operator<< interface,
+     * It supplies an iostream-like operator<< interface,
      * while still inheriting OutputStream
      */
     class PODOFO_API PdfStringStream final : public OutputStream

--- a/src/podofo/main/PdfTokenizer.cpp
+++ b/src/podofo/main/PdfTokenizer.cpp
@@ -149,7 +149,7 @@ bool PdfTokenizer::TryReadNextToken(InputStreamDevice& device, string_view& toke
             PdfTokenType tokenDelimiterType;
             if (IsTokenDelimiter(ch1, tokenDelimiterType))
             {
-                // All delimeters except << and >> (handled above) are
+                // All delimiters except << and >> (handled above) are
                 // one-character tokens, so if we hit one we can just return it
                 // immediately.
                 tokenType = tokenDelimiterType;
@@ -504,7 +504,7 @@ void PdfTokenizer::ReadString(InputStreamDevice& device, PdfVariant& variant, co
     bool octEscape = false;
     int octCharCount = 0;
     char octValue = 0;
-    int balanceCount = 0; // Balanced parathesis do not have to be escaped in strings
+    int balanceCount = 0; // Balanced parenthesis do not have to be escaped in strings
 
     m_charBuffer.clear();
     while (device.Read(ch))
@@ -636,7 +636,7 @@ void PdfTokenizer::ReadName(InputStreamDevice& device, PdfVariant& variant)
     if (!device.Peek(ch) || IsWhitespace(ch))
     {
         // We have an empty PdfName
-        // NOTE: Delimeters are handled correctly by tryReadNextToken
+        // NOTE: Delimiters are handled correctly by tryReadNextToken
         variant = PdfName();
         return;
     }

--- a/src/podofo/main/PdfVariant.h
+++ b/src/podofo/main/PdfVariant.h
@@ -187,7 +187,7 @@ public:
 
     /** Get the value of the object as int64_t
      *
-     *  This method throws if the numer is a floating point number
+     *  This method throws if the number is a floating point number
      *  \return the value of the number
      */
     int64_t GetNumber() const;
@@ -203,7 +203,7 @@ public:
 
     /** Get the value of the object as floating point number
      *
-     *  This method throws if the numer is integer
+     *  This method throws if the number is integer
      *  \return the value of the number
      */
     double GetRealStrict() const;

--- a/src/podofo/main/PdfXMPPacket.cpp
+++ b/src/podofo/main/PdfXMPPacket.cpp
@@ -304,7 +304,7 @@ xmlDocPtr createXMPDoc(xmlNodePtr& root)
         THROW_LIBXML_EXCEPTION("Can't create xpacket begin node");
     }
 
-    // NOTE: x:xmpmeta element does't define any attribute
+    // NOTE: x:xmpmeta element doesn't define any attribute
     // but other attributes can be defined (eg. x:xmptk)
     // and should be ignored by processors
     auto xmpmeta = xmlNewChild((xmlNodePtr)doc, nullptr, XMLCHAR "xmpmeta", nullptr);

--- a/src/podofo/main/PdfXRef.cpp
+++ b/src/podofo/main/PdfXRef.cpp
@@ -207,7 +207,7 @@ const PdfReference* PdfXRef::getNextFreeObject(XRefBlockList::const_iterator itB
 
 uint32_t PdfXRef::GetSize() const
 {
-    // From the PdfReference: /Size's value is 1 greater than the highes object number used in the file.
+    // From the PdfReference: /Size's value is 1 greater than the highest object number used in the file.
     return m_maxObjCount + 1;
 }
 

--- a/src/podofo/main/PdfXRefEntry.h
+++ b/src/podofo/main/PdfXRefEntry.h
@@ -36,7 +36,7 @@ namespace PoDoFo
         union
         {
             uint64_t ObjectNumber;  // Object number in Free and Compressed entries
-            uint64_t Offset;        // Unsed in InUse entries
+            uint64_t Offset;        // Unused in InUse entries
             uint64_t Unknown1;
         };
 

--- a/src/podofo/private/JpegCommon.cpp
+++ b/src/podofo/private/JpegCommon.cpp
@@ -18,7 +18,7 @@ extern "C"
 {
 // NOTE: Ignore MSVC warning C4297 ("function assumed not to throw
 // an exception but does") because of extern "C": we will catch
-// the exeception in a C++ method
+// the exception in a C++ method
 #pragma warning(push)
 #pragma warning(disable: 4297)
     void cust_error_exit(j_common_ptr ctx)

--- a/src/podofo/private/PdfDeclarationsPrivate.h
+++ b/src/podofo/private/PdfDeclarationsPrivate.h
@@ -33,7 +33,7 @@
 #include <podofo/main/PdfDeclarations.h>
 
 #ifdef _WIN32
-// Microsft itself assumes little endian
+// Microsoft itself assumes little endian
 // https://github.com/microsoft/STL/blob/b11945b73fc1139d3cf1115907717813930cedbf/stl/inc/bit#L336
 #define PODOFO_IS_LITTLE_ENDIAN
 #else // Unix
@@ -89,7 +89,7 @@
 
 // This is a do nothing macro that can be used to define
 // an invariant property without actually checking for it,
-// not even in DEBUG build. It's user responsability to
+// not even in DEBUG build. It's user responsibility to
 // ensure it's actually satisfied
 #define PODOFO_INVARIANT(x)
 

--- a/src/podofo/private/PdfDrawingOperations.cpp
+++ b/src/podofo/private/PdfDrawingOperations.cpp
@@ -561,7 +561,7 @@ void PoDoFo::WriteOperator_Extension(PdfStringStream& stream, const string_view&
 }
 
 /*
- * Coverts a rectangle to an array of points which can be used
+ * Converts a rectangle to an array of points which can be used
  * to draw an ellipse using 4 bezier curves.
  *
  * The arrays plPointX and plPointY need space for at least 12 longs

--- a/src/podofo/private/PdfEncodingPrivate.h
+++ b/src/podofo/private/PdfEncodingPrivate.h
@@ -19,7 +19,7 @@ namespace PoDoFo
     constexpr size_t ZapfDingbatsEncodingId     = 23;
     constexpr size_t CustomEncodingStartId      = 101;
 
-    /** Check if the chars in the given utf-8 view are elegible for PdfDocEncofing conversion
+    /** Check if the chars in the given utf-8 view are eligible for PdfDocEncofing conversion
      *
      * /param isPdfDocEncoding the given utf-8 string is coincident in PdfDocEncoding representation
      */

--- a/src/podofo/private/PdfFiltersPrivate.cpp
+++ b/src/podofo/private/PdfFiltersPrivate.cpp
@@ -21,7 +21,7 @@ namespace PoDoFo {
 const unsigned s_Powers85[] = { 85 * 85 * 85 * 85, 85 * 85 * 85, 85 * 85, 85, 1 };
 
 /**
- * This structur contains all necessary values
+ * This structure contains all necessary values
  * for a FlateDecode and LZWDecode Predictor.
  * These values are normally stored in the /DecodeParams
  * key of a PDF dictionary.

--- a/src/podofo/staging/PdfPainterExtensions.h
+++ b/src/podofo/staging/PdfPainterExtensions.h
@@ -14,7 +14,7 @@ namespace PoDoFo {
     class PdfPainterPathContext;
 
     /**
-     * This class cointains some extensions methods to PdfPainterPath
+     * This class contains some extension methods to PdfPainterPath
      * The class mostly implements some SVG commands by using
      * regular PDF operators by maintaining an internal state
      * \remarks This class is not maintained and its use

--- a/src/podofo/staging/PdfShadingPattern.h
+++ b/src/podofo/staging/PdfShadingPattern.h
@@ -30,7 +30,7 @@ enum class PdfShadingPatternType
 
 /**
  * This class defined a shading pattern which can be used
- * to fill abitrary shapes with a pattern using PdfPainter.
+ * to fill arbitrary shapes with a pattern using PdfPainter.
  */
 class PODOFO_API PdfShadingPattern : public PdfDictionaryElement
 {

--- a/src/podofo/staging/PdfTilingPattern.h
+++ b/src/podofo/staging/PdfTilingPattern.h
@@ -33,7 +33,7 @@ enum class PdfTilingPatternType
 
 /**
  * This class defined a tiling pattern which can be used
- * to fill abitrary shapes with a pattern using PdfPainter.
+ * to fill arbitrary shapes with a pattern using PdfPainter.
  */
 class PODOFO_API PdfTilingPattern final : public PdfDictionaryElement
 {

--- a/test/CreationTest/CreationTest.cpp
+++ b/test/CreationTest/CreationTest.cpp
@@ -947,7 +947,7 @@ int main( int argc, char* argv[] )
         writer.GetNamesTree()->AddValue( "TestDict", PdfString( "Berta" ), PdfVariant( 42L )  );
 #endif
 
-        printf("Setting document informations.\n\n");
+        printf("Setting document information.\n\n");
         // Setup the document information dictionary
         TEST_SAFE_OP( writer.GetInfo()->SetCreator ( PdfString("CreationTest - A simple test application") ) );
         TEST_SAFE_OP( writer.GetInfo()->SetAuthor  ( PdfString("Dominik Seichter") ) );
@@ -985,7 +985,7 @@ int main( int argc, char* argv[] )
         fclose( hFile );
 #endif
     } catch( PdfError & e ) {
-        std::cerr << "Error: An error " << e.GetError() << " ocurred." << std::endl;
+        std::cerr << "Error: An error " << e.GetError() << " occurred." << std::endl;
         e.PrintErrorMsg();
         return e.GetError();
     }

--- a/test/FilterTest/FilterTest.cpp
+++ b/test/FilterTest/FilterTest.cpp
@@ -302,6 +302,6 @@ int main()
         return e.GetError();
     }
 
-    printf("All tests sucessfull!\n");
+    printf("All tests successful!\n");
     return 0;
 }

--- a/test/FormTest/FormTest.cpp
+++ b/test/FormTest/FormTest.cpp
@@ -84,14 +84,14 @@ void CreateComplexForm( PdfPage* pPage, PdfStreamedDocument* pDoc )
 
     // Open Source
     y -= 11000.0 * CONVERSION_CONSTANT;
-    painter.DrawText( x, y, "I wan't to use PoDoFo in an Open Source application" );
+    painter.DrawText( x, y, "I want to use PoDoFo in an Open Source application" );
     PdfCheckBox checkOpenSource( pPage, PdfRect( 120000.0 * CONVERSION_CONSTANT, y - 2500.0 * CONVERSION_CONSTANT,
                                                  h, h ), pDoc );
     checkOpenSource.SetFieldName("field_check_oss");
 
     // Commercial
     y -= 11000.0 * CONVERSION_CONSTANT;
-    painter.DrawText( x, y, "I wan't to use PoDoFo in a commercial application" );
+    painter.DrawText( x, y, "I want to use PoDoFo in a commercial application" );
     PdfCheckBox checkCom( pPage, PdfRect( 120000.0 * CONVERSION_CONSTANT, y - 2500.0 * CONVERSION_CONSTANT,
                                           h, h ), pDoc );
     checkCom.SetFieldName("field_check_com");
@@ -346,7 +346,7 @@ int main( int argc, char* argv[] )
             TEST_SAFE_OP( writer.Close() );
         }
     } catch( PdfError & e ) {
-        std::cerr << "Error: An error " << e.GetError() << " ocurred." << std::endl;
+        std::cerr << "Error: An error " << e.GetError() << " occurred." << std::endl;
         e.PrintErrorMsg();
         return e.GetError();
     }

--- a/test/ParserTest/ParserTest.cpp
+++ b/test/ParserTest/ParserTest.cpp
@@ -65,7 +65,7 @@ void enc_test()
                          enc.GetPValue(), 40, 2) )
     {
 
-        printf("Successfull\n");
+        printf("Successful\n");
     }
     else
         printf("FAILED\n");

--- a/test/README.md
+++ b/test/README.md
@@ -4,6 +4,6 @@ Ensure the submodules are initialized by running the following command:
 
     git submodule update --init
 
-Testing fixtures and output is avaialable through
+Testing fixtures and output is available through
 `TestUtils::GetTestOutputFilePath(filename)` and
 `TestUtils::GetTestInputFilePath(filename)`.

--- a/test/SignTest/SignTest.cpp
+++ b/test/SignTest/SignTest.cpp
@@ -99,7 +99,7 @@ int main( int argc, char* argv[] )
 
         signer.Flush();
     } catch( PdfError & e ) {
-        std::cerr << "Error: An error " << e.GetError() << " ocurred." << std::endl;
+        std::cerr << "Error: An error " << e.GetError() << " occurred." << std::endl;
         e.PrintErrorMsg();
         return e.GetError();
     }

--- a/test/SignatureTest/NSSSignatureGenerator.cpp
+++ b/test/SignatureTest/NSSSignatureGenerator.cpp
@@ -87,7 +87,7 @@ NSSCMSMessage* NSSSignatureGenerator::createSign(CERTCertificate *cert)
         NSS_CMSMessage_Destroy(cmsg); return NULL;
     }
     
-    // if !detatched, the contentinfo will alloc a data item for us
+    // if !detached, the contentinfo will alloc a data item for us
     cinfo = NSS_CMSSignedData_GetContentInfo(sigd);
     if (NSS_CMSContentInfo_SetContent_Data(cmsg, cinfo, NULL, PR_TRUE ) != SECSuccess) {
         NSS_CMSMessage_Destroy(cmsg); return NULL;

--- a/test/SignatureTest/NSSSignatureGenerator.h
+++ b/test/SignatureTest/NSSSignatureGenerator.h
@@ -33,7 +33,7 @@ private:
 	static void sm_write_stream(void *arg, const char *buf, unsigned long len);
 
 protected:
-    // get digest algoritm for the signing algoritm
+    // get digest algorithm for the signing algorithm
 	static SECOidTag getDigestAlgor(CERTCertificate *pCert);
 
 	// create message with signature

--- a/test/SignatureTest/SignTest.cpp
+++ b/test/SignatureTest/SignTest.cpp
@@ -160,7 +160,7 @@ int main( int argc, char* argv[] )
 
         signer.Flush();
     } catch( PdfError & e ) {
-        std::cerr << "Error: An error " << e.GetError() << " ocurred." << std::endl;
+        std::cerr << "Error: An error " << e.GetError() << " occurred." << std::endl;
         e.PrintErrorMsg();
         return e.GetError();
     }

--- a/test/VariantTest/VariantTest.cpp
+++ b/test/VariantTest/VariantTest.cpp
@@ -128,7 +128,7 @@ int main()
 
     // testing strings
     TEST_SAFE_OP( Test( "(Hallo Welt!)", ePdfDataType_String ) );
-    TEST_SAFE_OP( Test( "(Hallo \\(schöne\\) Welt!)", ePdfDataType_String ) );
+    TEST_SAFE_OP( Test( "(Hallo \\(schï¿½ne\\) Welt!)", ePdfDataType_String ) );
     TEST_SAFE_OP( Test( "(Balanced () brackets are (ok ()) in PDF Strings)", ePdfDataType_String,
                         "(Balanced \\(\\) brackets are \\(ok \\(\\)\\) in PDF Strings)" ) );
     TEST_SAFE_OP( Test( "()", ePdfDataType_String ) );
@@ -181,13 +181,13 @@ int main()
     printf("---\n");
 
     // testing arrays
-    TEST_SAFE_OP_IGNORE( Test( "[]", ePdfDataType_Array ) );  // this test may fail as the formating is different
+    TEST_SAFE_OP_IGNORE( Test( "[]", ePdfDataType_Array ) );  // this test may fail as the formatting is different
     TEST_SAFE_OP( Test( "[ ]", ePdfDataType_Array ) );
     TEST_SAFE_OP( Test( "[ 1 2 3 4 ]", ePdfDataType_Array ) );
-    TEST_SAFE_OP_IGNORE( Test( "[1 2 3 4]", ePdfDataType_Array ) ); // this test may fail as the formating is different
+    TEST_SAFE_OP_IGNORE( Test( "[1 2 3 4]", ePdfDataType_Array ) ); // this test may fail as the formatting is different
     TEST_SAFE_OP( Test( "[ 2 (Hallo Welt!) 3.500000 /FMC ]", ePdfDataType_Array ) );
     TEST_SAFE_OP( Test( "[ [ 1 2 ] (Hallo Welt!) 3.500000 /FMC ]", ePdfDataType_Array ) );
-    TEST_SAFE_OP_IGNORE( Test( "[/ImageA/ImageB/ImageC]", ePdfDataType_Array ) ); // this test may fail as the formating is different
+    TEST_SAFE_OP_IGNORE( Test( "[/ImageA/ImageB/ImageC]", ePdfDataType_Array ) ); // this test may fail as the formatting is different
     TEST_SAFE_OP_IGNORE( Test( "[<530464995927cef8aaf46eb953b93373><530464995927cef8aaf46eb953b93373>]", ePdfDataType_Array ) );
     TEST_SAFE_OP_IGNORE( Test( "[ 2 0 R (Test Data) 4 << /Key /Data >> 5 0 R ]", ePdfDataType_Array ) );
     TEST_SAFE_OP_IGNORE( Test( "[<</key/name>>2 0 R]", ePdfDataType_Array ) );

--- a/test/unit/EncryptTest.cpp
+++ b/test/unit/EncryptTest.cpp
@@ -341,7 +341,7 @@ void createEncryptedPdf(const string_view& filename)
 
     auto font = doc.GetFonts().SearchFont("LiberationSans");
     if (font == nullptr)
-        FAIL("Coult not find Arial font");
+        FAIL("Could not find Arial font");
 
     painter.TextState.SetFont(*font, 16);
     painter.DrawText("Hello World", 100, 100);

--- a/test/unit/PageTreeTest.cpp
+++ b/test/unit/PageTreeTest.cpp
@@ -99,7 +99,7 @@ TEST_CASE("testCreateDelete")
     // create font
     auto font = doc.GetFonts().SearchFont("LiberationSans");
     if (font == nullptr)
-        FAIL("Coult not find Arial font");
+        FAIL("Could not find Arial font");
 
     {
         // write 1. page
@@ -340,7 +340,7 @@ vector<unique_ptr<PdfPage>> PdfPageTest::CreateSamplePages(PdfMemDocument& doc, 
     // create font
     auto font = doc.GetFonts().SearchFont("LiberationSans");
     if (font == nullptr)
-        FAIL("Coult not find Arial font");
+        FAIL("Could not find Arial font");
 
     vector<unique_ptr<PdfPage>> pages(pageCount);
     for (unsigned i = 0; i < pageCount; ++i)

--- a/test/unit/ParserTest.cpp
+++ b/test/unit/ParserTest.cpp
@@ -9,7 +9,7 @@
 /*
     Notes:
 
-    1) out of memory tests don't run if Address Santizer (ASAN) is enabled because
+    1) out of memory tests don't run if Address Sanitizer (ASAN) is enabled because
        ASAN terminates the unit test process the first time it attempts to allocate
        too much memory (so running the tests with and without ASAN is recommended)
 
@@ -240,7 +240,7 @@ TEST_CASE("TestReadXRefContents")
         oss << "xref\r\n0 1\r\n";
         oss << generateXRefEntries(1);
 
-        // XRef stream at offsetXrefStm1, but any /Prev entries pointing to any offet between
+        // XRef stream at offsetXrefStm1, but any /Prev entries pointing to any offset between
         // offsetXrefStm1Whitespace and offsetXrefStm1 point to the same /Prev section
         // because the PDF processing model says tokenizer must discard whitespace and comments
         size_t offsetXrefStm1Whitespace = oss.str().length();

--- a/tools/podofoencrypt/podofoencrypt.cpp
+++ b/tools/podofoencrypt/podofoencrypt.cpp
@@ -67,7 +67,7 @@ void print_help()
     printf("       --print       Allow printing the document\n");
     printf("       --edit        Allow modifying the document besides annotations, form fields or changing pages\n");
     printf("       --copy        Allow text and graphic extraction\n");
-    printf("       --editnotes   Add or modify text annoations or form fields (if PdfPermissions::Edit is set also allow the creation interactive form fields including signature)\n");
+    printf("       --editnotes   Add or modify text annotations or form fields (if PdfPermissions::Edit is set also allow the creation interactive form fields including signature)\n");
     printf("       --fillandsign Fill in existing form or signature fields\n");
     printf("       --accessible  Extract text and graphics to support user with disabillities\n");
     printf("       --assemble    Assemble the document: insert, create, rotate delete pages or add bookmarks\n");

--- a/tools/podofoimgextract/ImageExtractor.h
+++ b/tools/podofoimgextract/ImageExtractor.h
@@ -27,7 +27,7 @@ public:
     void Init(const std::string_view& input, const std::string_view& output);
 
     /**
-     * \returns the number of succesfully extracted images
+     * \returns the number of successfully extracted images
      */
     inline unsigned GetNumImagesExtracted() const;
 
@@ -40,7 +40,7 @@ private:
      */
     void ExtractImage(const PoDoFo::PdfObject& obj, bool jpeg);
 
-    /** This function checks wether a file with the
+    /** This function checks whether a file with the
      *  given filename does exist.
      *  \returns true if the file exists otherwise false
      */

--- a/tools/podofoimpose/README.html
+++ b/tools/podofoimpose/README.html
@@ -60,7 +60,7 @@ body{
 	
 	<h3>Plan (built-in)</h3>
 	<div class="section"><!-- Plan own -->
-		PodofoImpose is driven by a PLAN file. This file describes how pages from a source PDF document have to be relayout into a target document. We’ll describe how this file must be formated.
+		PodofoImpose is driven by a PLAN file. This file describes how pages from a source PDF document have to be relayout into a target document. We’ll describe how this file must be formatted.
 		<h4>Records</h4>
 		<div>
 			Most of the PLAN file is composed of record lines of the form:
@@ -88,7 +88,7 @@ body{
 			<div class="code-abs">
 				$ValueA / ( $ValueB | 0.000001 )
 			</div>
- 			Operations are executed from left to right without taking care of any kind of precedance. You can use parenthesis to enclose operations that need to be computed separetly. Example:
+ 			Operations are executed from left to right without taking care of any kind of precedance. You can use parenthesis to enclose operations that need to be computed separately. Example:
 			<div class="code-abs">
 				123.456 * ( $ConstantA - ( $ConstantB / 3.14 ) )
 			</div>
@@ -139,7 +139,7 @@ $page; $page; 0; ($PageWidth-$sw)/2; ($PageHeight-$sh)/2;
 	     <div class="command">
 	      PushRecord(source page, target page, rotation, x, y);
 	      </div>
-		As for regular plan files, there are a couple of provided informations through global variables, specifically: "SourceWidth", "SourceHeight", "PageCount". You need to set "PageWidth" and "PageHeight". You may alter the global scale factor (from source to target) by setting "Scale".
+		As for regular plan files, there are a couple of provided information through global variables, specifically: "SourceWidth", "SourceHeight", "PageCount". You need to set "PageWidth" and "PageHeight". You may alter the global scale factor (from source to target) by setting "Scale".
 	     </div>
 		<h4>Running</h4>
 		 <div>
@@ -168,7 +168,7 @@ stamp.pdf</div>
 $PageHeight=842.4
 # original page is left unchanged;
 1; 1; 0; 0; 0;
-# positionning stamp is up to you!
+# positioning stamp is up to you!
 2; 1; 0; 350; 100;</div>
 	</div>
 	Now you can run:

--- a/tools/podofopages/podofopages.cpp
+++ b/tools/podofopages/podofopages.cpp
@@ -144,7 +144,7 @@ void Main(const cspan<string_view>& args)
 
     work(inputPath, outputPath, operations);
 
-    // Delete operations vectore
+    // Delete operations vector
     vector<Operation*>::iterator it = operations.begin();
     while (it != operations.end())
     {

--- a/tools/podofosign/podofosign.cpp
+++ b/tools/podofosign/podofosign.cpp
@@ -241,7 +241,7 @@ static void print_help(bool bOnlyUsage)
     cout << "       text ... the actual UTF-8 encoded string to add to the annotation" << endl;
     cout << "  -annot-image [left,top,width,height,filename] ... an image to add to the annotation" << endl;
     cout << "       left,top,width,height ... a rectangle (in annot-units) where to place the image (double), relative to annot-position" << endl;
-    cout << "       filename ... a filname of the image to add" << endl;
+    cout << "       filename ... a filename of the image to add" << endl;
     cout << "The annotation arguments can be repeated, except of the -annot-position and -annot-print, which can appear up to once." << endl;
     cout << "The -annot-print, -annot-font, -annot-text and -annot-image can appear only after -annot-position." << endl;
     cout << "All the left,top positions are treated with 0,0 being at the left-top of the page." << endl;
@@ -950,7 +950,7 @@ void Main(const cspan<string_view>& args)
         X509_free(cert);
 }
 
-// TODO: Optmize so the process is buffered
+// TODO: Optimize so the process is buffered
 void MySigner::ComputeSignature(charbuff& buffer, bool dryrun)
 {
     (void)dryrun;

--- a/tools/private/MainEntryPoint.cpp
+++ b/tools/private/MainEntryPoint.cpp
@@ -36,7 +36,7 @@ int main(int argc, char* argv[])
     }
     catch (const PdfError& ex)
     {
-        cerr << "ERROR: An error ocurred during processing the pdf file" << endl;
+        cerr << "ERROR: An error occurred during processing the pdf file" << endl;
         cerr << ex.what() << endl;
         return (int)ex.GetCode();
     }


### PR DESCRIPTION
- [X] Accept to license the library and tools code under the terms
  of the [LGPL 2.0](https://spdx.org/licenses/LGPL-2.0-or-later.html) or later
- [X] Accept to license the library and tools code under the terms
  of the [MPL 2.0](https://spdx.org/licenses/MPL-2.0)
- [X] Accept to license the test code under the terms
  of the [MIT-0](https://spdx.org/licenses/MIT-0.html)
- [X] Read [contributions](https://github.com/podofo/podofo#contributions) guidelines
- [X] Checked coding [style](https://github.com/podofo/podofo/blob/master/CODING-STYLE.md)
- [X] The commits sequence is clean without work in progress/bugged revisions and merge commits. In doubt, [squash](https://github.com/podofo/podofo/wiki/Squash-git-history-guide) the commits and/or rebase master

Includes user-facing and non-user-facing typos. 

Found via `codespell -q 3 -S "*.pdf,./3rdparty" -L currect,fase,fith,flate,nd,parial,seh,ue` along with vscode search functionality.