### PR TITLE
Install man pages in directory from GNUInstallDirs

### DIFF
--- a/man/CMakeLists.txt
+++ b/man/CMakeLists.txt
@@ -17,5 +17,5 @@ INSTALL(FILES
   podofotxtextract.1
   podofouncompress.1
   podofoxmp.1
-  DESTINATION ${MANDIR}man1
+  DESTINATION ${CMAKE_INSTALL_MANDIR}/man1
   )


### PR DESCRIPTION
Apparently MANDIR is no longer set by the parent CMakeLists.txt, so this is not only a good idea, it's necessary.

- [x] Accept to license the library and tools code under the terms
  of the LGPL 2.0 or later
- [x] Accept to license the library and tools code under the terms
  of the MPL 2.0
- [x] Accept to license the test code under the terms
  of the MIT-0
- [x] Read contributions guidelines
- [x] Checked coding style
- [x] The commits sequence is clean without work in progress/bugged revisions and merge commits.