### PR TITLE
Fixes for InsertDocumentPageAt

### DIFF
--- a/src/podofo/main/PdfDocument.cpp
+++ b/src/podofo/main/PdfDocument.cpp
@@ -213,7 +213,7 @@ void PdfDocument::InsertDocumentPageAt(unsigned atIndex, const PdfDocument& doc,
     // prevent overlapping obj-numbers
 
     // create all free objects again, to have a clean free object list
-    for (auto& freeObj : GetObjects().GetFreeObjects())
+    for (auto& freeObj : doc.GetObjects().GetFreeObjects())
     {
         m_Objects.AddFreeObject(PdfReference(freeObj.ObjectNumber() + difference, freeObj.GenerationNumber()));
     }

--- a/src/podofo/main/PdfDocument.cpp
+++ b/src/podofo/main/PdfDocument.cpp
@@ -265,20 +265,6 @@ void PdfDocument::InsertDocumentPageAt(unsigned atIndex, const PdfDocument& doc,
 
     m_Pages->InsertPageAt(atIndex, *new PdfPage(obj));
 
-    // append all outlines
-    PdfOutlineItem* root = this->GetOutlines();
-    PdfOutlines* appendRoot = const_cast<PdfDocument&>(doc).GetOutlines();
-    if (appendRoot != nullptr && appendRoot->First())
-    {
-        // only append outlines if appended document has outlines
-        while (root != nullptr && root->Next())
-            root = root->Next();
-
-        PdfReference ref(appendRoot->First()->GetObject().GetIndirectReference().ObjectNumber()
-            + difference, appendRoot->First()->GetObject().GetIndirectReference().GenerationNumber());
-        root->InsertChild(unique_ptr<PdfOutlineItem>(new PdfOutlines(m_Objects.MustGetObject(ref))));
-    }
-
     // TODO: merge name trees
     // ToDictionary -> then iteratate over all keys and add them to the new one
 }


### PR DESCRIPTION
- [ x] Accept to license the library and tools code under the terms
  of the [LGPL 2.0](https://spdx.org/licenses/LGPL-2.0-or-later.html) or later
- [ x] Accept to license the library and tools code under the terms
  of the [MPL 2.0](https://spdx.org/licenses/MPL-2.0)
- [ x] Accept to license the test code under the terms
  of the [MIT-0](https://spdx.org/licenses/MIT-0.html)
- [ x] Read [contributions](https://github.com/podofo/podofo#contributions) guidelines
- [ x] Checked coding [style](https://github.com/podofo/podofo/blob/master/CODING-STYLE.md)
- [ x] The commits sequence is clean without work in progress/bugged revisions and merge commits. In doubt, [squash](https://github.com/podofo/podofo/wiki/Squash-git-history-guide) the commits and/or rebase master

The fix in the commit 202f6af ("Add free objects from other doc not self") is necessary for the InsertDocumentPageAt function to work at all.