### PR TITLE
Free the SSL context after unloading the provider libs

### DIFF
--- a/src/podofo/private/OpenSSLInternal.cpp
+++ b/src/podofo/private/OpenSSLInternal.cpp
@@ -76,9 +76,9 @@ OpenSSLMain::~OpenSSLMain()
     if (m_libCtx == nullptr)
         return;
 
-    OSSL_LIB_CTX_free(m_libCtx);
     OSSL_PROVIDER_unload(m_legacyProvider);
     OSSL_PROVIDER_unload(m_defaultProvider);
+    OSSL_LIB_CTX_free(m_libCtx);
 #endif // OPENSSL_VERSION_MAJOR >= 3
 }
 


### PR DESCRIPTION
Otherwise crashes on linux in dtor

- [ x] Accept to license the library and tools code under the terms
  of the [LGPL 2.0](https://spdx.org/licenses/LGPL-2.0-or-later.html) or later
- [ x] Accept to license the library and tools code under the terms
  of the [MPL 2.0](https://spdx.org/licenses/MPL-2.0)
- [ x] Accept to license the test code under the terms
  of the [MIT-0](https://spdx.org/licenses/MIT-0.html)
- [ x] Read [contributions](https://github.com/podofo/podofo#contributions) guidelines
- [ x] Checked coding [style](https://github.com/podofo/podofo/blob/master/CODING-STYLE.md)
- [ x] The commits sequence is clean without work in progress/bugged revisions and merge commits. In doubt, [squash](https://github.com/podofo/podofo/wiki/Squash-git-history-guide) the commits and/or rebase master

This is the fix for SSL context/provider destruction order