### PR TITLE
Fix incorrect cmap codespacerange size

### DIFF
--- a/src/podofo/main/PdfEncoding.cpp
+++ b/src/podofo/main/PdfEncoding.cpp
@@ -620,11 +620,7 @@ void PdfEncoding::writeCIDMapping(PdfObject& cmapObj, const PdfFont& font, const
     }
     else
     {
-        output.Write("1 begincodespacerange\n");
-
         m_Encoding->AppendCodeSpaceRange(output, temp);
-
-        output.Write("\nendcodespacerange\n");
     }
 
     if (font.IsSubsettingEnabled())

--- a/src/podofo/main/PdfEncoding.cpp
+++ b/src/podofo/main/PdfEncoding.cpp
@@ -566,7 +566,7 @@ void PdfEncoding::writeCIDMapping(PdfObject& cmapObj, const PdfFont& font, const
         ">> def\n"
         "/CMapName /{} def\n"
         "/CMapType 1 def\n"     // As defined in Adobe Technical Notes #5099
-        "1 begincodespacerange\n", fontName, cmapName);
+        , fontName, cmapName);
     output.Write(temp);
 
     if (font.IsSubsettingEnabled())
@@ -598,6 +598,9 @@ void PdfEncoding::writeCIDMapping(PdfObject& cmapObj, const PdfFont& font, const
             }
         }
 
+        output.Write(std::to_string(ranges.size()));
+        output.Write(" begincodespacerange\n");
+
         bool first = true;
         for (auto& pair : ranges)
         {
@@ -612,13 +615,17 @@ void PdfEncoding::writeCIDMapping(PdfObject& cmapObj, const PdfFont& font, const
             range.LastCode.WriteHexTo(temp);
             output.Write(temp);
         }
+
+        output.Write("\nendcodespacerange\n");
     }
     else
     {
-        m_Encoding->AppendCodeSpaceRange(output, temp);
-    }
+        output.Write("1 begincodespacerange\n");
 
-    output.Write("\nendcodespacerange\n");
+        m_Encoding->AppendCodeSpaceRange(output, temp);
+
+        output.Write("\nendcodespacerange\n");
+    }
 
     if (font.IsSubsettingEnabled())
     {
@@ -669,10 +676,8 @@ void PdfEncoding::writeToUnicodeCMap(PdfObject& cmapObj) const
         "   /Supplement 0\n"
         ">> def\n"
         "/CMapName /Adobe-Identity-UCS def\n"
-        "/CMapType 2 def\n"     // As defined in Adobe Technical Notes #5099
-        "1 begincodespacerange\n");
+        "/CMapType 2 def\n");     // As defined in Adobe Technical Notes #5099
     toUnicode.AppendCodeSpaceRange(output, temp);
-    output.Write("\nendcodespacerange\n");
 
     toUnicode.AppendToUnicodeEntries(output, temp);
     output.Write(

--- a/src/podofo/main/PdfEncodingMap.cpp
+++ b/src/podofo/main/PdfEncodingMap.cpp
@@ -272,11 +272,13 @@ void PdfEncodingMap::AppendUTF16CodeTo(OutputStream& stream, const unicodeview& 
 
 void PdfEncodingMap::AppendCodeSpaceRange(OutputStream& stream, charbuff& temp) const
 {
+    stream.Write("1 begincodespacerange\n");
     auto& limits = GetLimits();
     limits.FirstChar.WriteHexTo(temp);
     stream.Write(temp);
     limits.LastChar.WriteHexTo(temp);
     stream.Write(temp);
+    stream.Write("\nendcodespacerange\n");
 }
 
 PdfEncodingMapBase::PdfEncodingMapBase(PdfCharCodeMap&& map, PdfEncodingMapType type)
@@ -333,6 +335,9 @@ void PdfEncodingMapBase::AppendCodeSpaceRange(OutputStream& stream, charbuff& te
         }
     }
 
+    stream.Write(std::to_string(ranges.size()));
+    stream.Write(" begincodespacerange\n");
+
     bool first = true;
     for (auto& pair : ranges)
     {
@@ -347,6 +352,8 @@ void PdfEncodingMapBase::AppendCodeSpaceRange(OutputStream& stream, charbuff& te
         range.LastCode.WriteHexTo(temp);
         stream.Write(temp);
     }
+
+    stream.Write("\nendcodespacerange\n");
 }
 
 void PdfEncodingMapBase::AppendToUnicodeEntries(OutputStream& stream, charbuff& temp) const


### PR DESCRIPTION
I found an error in the size of codespacerange when the size of the ranges variable is not 1.
This error generates an illegal cmap stream causing the acrobat reader to not parse the PDF properly.

- [x] Accept to license the library and tools code under the terms
  of the [LGPL 2.0](https://spdx.org/licenses/LGPL-2.0-or-later.html) or later
- [x] Accept to license the library and tools code under the terms
  of the [MPL 2.0](https://spdx.org/licenses/MPL-2.0)
- [x] Accept to license the test code under the terms
  of the [MIT-0](https://spdx.org/licenses/MIT-0.html)
- [x] Read [contributions](https://github.com/podofo/podofo#contributions) guidelines
- [x] Checked coding [style](https://github.com/podofo/podofo/blob/master/CODING-STYLE.md)
- [x] The commits sequence is clean without work in progress/bugged revisions and merge commits. In doubt, [squash](https://github.com/podofo/podofo/wiki/Squash-git-history-guide) the commits and/or rebase master
