### PR TITLE
fix tools build for mingw

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -10,6 +10,9 @@ if (MSVC)
     # Force requirement for unicode entry point
     add_link_options(/ENTRY:wmainCRTStartup)
 else()
+    if (MINGW)
+        add_link_options(-municode)
+    endif()
     # TODO: Remove me when all the tools are cleaned of use of C functions
     add_compile_options(-Wno-deprecated-declarations)
 endif()


### PR DESCRIPTION
add `-municode` LDFLAG for `WinMain` symbol. IS NOT related to #152

- [x] Accept to license the library and tools code under the terms
  of the [LGPL 2.0](https://spdx.org/licenses/LGPL-2.0-or-later.html) or later
- [x] Accept to license the library and tools code under the terms
  of the [MPL 2.0](https://spdx.org/licenses/MPL-2.0)
- [x] Accept to license the test code under the terms
  of the [MIT-0](https://spdx.org/licenses/MIT-0.html)
- [x] Read [contributions](https://github.com/podofo/podofo#contributions) guidelines
- [x] Checked coding [style](https://github.com/podofo/podofo/blob/master/CODING-STYLE.md)
- [x] The commits sequence is clean without work in progress/bugged revisions and merge commits. In doubt, [squash](https://github.com/podofo/podofo/wiki/Squash-git-history-guide) the commits and/or rebase master
