### PR TITLE
fixed offset on multiline text if text is not left aligned

### DIFF
--- a/src/podofo/main/PdfPainter.cpp
+++ b/src/podofo/main/PdfPainter.cpp
@@ -479,6 +479,18 @@ void PdfPainter::drawMultiLineText(const string_view& str, double x, double y, d
             this->drawTextAligned(line, x, y, width, hAlignment, style);
 
         x = 0;
+        switch (hAlignment)
+        {
+            default:
+            case PdfHorizontalAlignment::Left:
+                break;
+            case PdfHorizontalAlignment::Center:
+                x = -(width - textState.Font->GetStringLength(line, textState)) / 2.0;
+                break;
+            case PdfHorizontalAlignment::Right:
+                x = -(width - textState.Font->GetStringLength(line, textState));
+                break;
+        }
         y = -font.GetLineSpacing(textState);
     }
     PoDoFo::WriteOperator_ET(m_stream);


### PR DESCRIPTION
When using the painter.DrawTextMultiLine with multi line text and non-left-aligned text,
the first line is correctly positioned, the following lines are not.
The pull requests fixed the alignment issue.
There is still a white space at the end of the lines, this is not fixed with this pull request.
Manually breaking with \n works.

- [X] Accept to license the library and tools code under the terms
  of the [LGPL 2.0](https://spdx.org/licenses/LGPL-2.0-or-later.html) or later
- [X] Accept to license the library and tools code under the terms
  of the [MPL 2.0](https://spdx.org/licenses/MPL-2.0)
- [X] Accept to license the test code under the terms
  of the [MIT-0](https://spdx.org/licenses/MIT-0.html)
- [X] Read [contributions](https://github.com/podofo/podofo#contributions) guidelines
- [X] Checked coding [style](https://github.com/podofo/podofo/blob/master/CODING-STYLE.md)
- [X] The commits sequence is clean without work in progress/bugged revisions and merge commits. In doubt, [squash](https://github.com/podofo/podofo/wiki/Squash-git-history-guide) the commits and/or rebase master
