### PR TITLE
`brew` should also install `cmake` if needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ cmake --build . --config Debug
 Install [brew](https://brew.sh/), then from the source root run:
 
 ```
-brew install fontconfig freetype openssl libxml2 jpeg-turbo libpng libtiff libidn
+brew install fontconfig freetype openssl libxml2 jpeg-turbo libpng libtiff libidn cmake
 mkdir build
 cd build
 cmake  -DCMAKE_BUILD_TYPE=Debug -DCMAKE_FIND_FRAMEWORK=NEVER -DCMAKE_PREFIX_PATH=`brew --prefix` -DFontconfig_INCLUDE_DIR=`brew --prefix fontconfig`/include -DOPENSSL_ROOT_DIR=`brew --prefix openssl@3` ..


### PR DESCRIPTION
I assume the same change should also be done for the other build descriptions, but I have no way to check.

- [X] Accept to license the library and tools code under the terms
  of the [LGPL 2.0](https://spdx.org/licenses/LGPL-2.0-or-later.html) or later
- [X] Accept to license the library and tools code under the terms
  of the [MPL 2.0](https://spdx.org/licenses/MPL-2.0)
- [X] Accept to license the test code under the terms
  of the [MIT-0](https://spdx.org/licenses/MIT-0.html)
- [X] Read [contributions](https://github.com/podofo/podofo#contributions) guidelines
- [X] Checked coding [style](https://github.com/podofo/podofo/blob/master/CODING-STYLE.md)
- [X] The commits sequence is clean without work in progress/bugged revisions and merge commits. In doubt, [squash](https://github.com/podofo/podofo/wiki/Squash-git-history-guide) the commits and/or rebase master
