### PR TITLE
Filter `._*` from globbed source files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ x86/
 *.autosave
 .qmake.stash
 .*/
+._*
 *.kdev4
 *-swp
 .gradle/

--- a/test/common/cmake/ParseAndAddCatchTests.cmake
+++ b/test/common/cmake/ParseAndAddCatchTests.cmake
@@ -23,6 +23,7 @@
 #        include_directories(${INCLUDE_DIRECTORIES} ${CATCH_INCLUDE_DIR})                          #
 #                                                                                                  #
 #        file(GLOB SOURCE_FILES "*.cpp")                                                           #
+#        list(FILTER SOURCE_FILES EXCLUDE REGEX "^\\._")                                           #
 #        add_executable(${PROJECT_NAME} ${SOURCE_FILES})                                           #
 #                                                                                                  #
 #        include(ParseAndAddCatchTests)                                                            #

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -1,4 +1,5 @@
 file(GLOB SOURCE_FILES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "*.h" "*.cpp")
+list(FILTER SOURCE_FILES EXCLUDE REGEX "^\\._")
 source_group("" FILES ${SOURCE_FILES})
 
 include_directories(

--- a/tools/podofobox/CMakeLists.txt
+++ b/tools/podofobox/CMakeLists.txt
@@ -1,4 +1,5 @@
 file(GLOB SOURCE_FILES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "*.h" "*.cpp")
+list(FILTER SOURCE_FILES EXCLUDE REGEX "^\\._")
 source_group("" FILES ${SOURCE_FILES})
 add_executable(podofobox ${SOURCE_FILES})
 target_link_libraries(podofobox ${PODOFO_LIBRARIES} tools_private)

--- a/tools/podofocountpages/CMakeLists.txt
+++ b/tools/podofocountpages/CMakeLists.txt
@@ -1,4 +1,5 @@
 file(GLOB SOURCE_FILES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "*.h" "*.cpp")
+list(FILTER SOURCE_FILES EXCLUDE REGEX "^\\._")
 source_group("" FILES ${SOURCE_FILES})
 add_executable(podofocountpages ${SOURCE_FILES})
 target_link_libraries(podofocountpages ${PODOFO_LIBRARIES} tools_private)


### PR DESCRIPTION
Depending on the file system (in particular, network drives) and editors used, Mac OS X likes to write `._PdfWriter.cpp` and similar files, storing OS-level meta-information.

We do not want to pick up those files for the build, since they are obviously not valid cpp files. Filter them out from the `file(GLOB SOURCE_FILES …)` results.

- [X] Accept to license the library and tools code under the terms
  of the [LGPL 2.0](https://spdx.org/licenses/LGPL-2.0-or-later.html) or later
- [X] Accept to license the library and tools code under the terms
  of the [MPL 2.0](https://spdx.org/licenses/MPL-2.0)
- [X] Accept to license the test code under the terms
  of the [MIT-0](https://spdx.org/licenses/MIT-0.html)
- [X] Read [contributions](https://github.com/podofo/podofo#contributions) guidelines
- [X] Checked coding [style](https://github.com/podofo/podofo/blob/master/CODING-STYLE.md)
- [X] The commits sequence is clean without work in progress/bugged revisions and merge commits. In doubt, [squash](https://github.com/podofo/podofo/wiki/Squash-git-history-guide) the commits and/or rebase master
