### PR TITLE
Fix Typo: Do not call `GetDictionaryUnsafe` for `Array`

### DIFF
--- a/src/podofo/main/PdfObject.cpp
+++ b/src/podofo/main/PdfObject.cpp
@@ -183,7 +183,7 @@ void PdfObject::SetVariantOwner()
             m_Variant.GetDictionaryUnsafe().SetOwner(*this);
             break;
         case PdfDataType::Array:
-            m_Variant.GetDictionaryUnsafe().SetOwner(*this);
+            m_Variant.GetArrayUnsafe().SetOwner(*this);
             break;
         default:
             break;


### PR DESCRIPTION
This triggers `-fsanitize=undefined` while creating a `PdfMemDocument`. No test point added because I don't think there's any tests running with sanitizers right now, and existing tests do go through these lines.

- [X] Accept to license the library and tools code under the terms
  of the [LGPL 2.0](https://spdx.org/licenses/LGPL-2.0-or-later.html) or later
- [X] Accept to license the library and tools code under the terms
  of the [MPL 2.0](https://spdx.org/licenses/MPL-2.0)
- [X] Accept to license the test code under the terms
  of the [MIT-0](https://spdx.org/licenses/MIT-0.html)
- [X] Read [contributions](https://github.com/podofo/podofo#contributions) guidelines
- [X] Checked coding [style](https://github.com/podofo/podofo/blob/master/CODING-STYLE.md)
- [X] The commits sequence is clean without work in progress/bugged revisions and merge commits. In doubt, [squash](https://github.com/podofo/podofo/wiki/Squash-git-history-guide) the commits and/or rebase master
