### PR TITLE
Avoid a harmless UB

### DIFF
--- a/src/podofo/main/PdfParser.cpp
+++ b/src/podofo/main/PdfParser.cpp
@@ -450,7 +450,7 @@ void PdfParser::ReadXRefSubsection(InputStreamDevice& device, int64_t& firstObje
     if (objectCount < 0)
         PODOFO_RAISE_ERROR_INFO(PdfErrorCode::ValueOutOfRange, "ReadXRefSubsection: object count is negative");
 
-    m_entries.Enlarge(static_cast<uint64_t>(firstObject) + static_cast<uint64_t>(objectCount));
+    m_entries.Enlarge(firstObject + objectCount);
 
     // consume all whitespaces
     char ch;

--- a/src/podofo/main/PdfParser.cpp
+++ b/src/podofo/main/PdfParser.cpp
@@ -450,7 +450,7 @@ void PdfParser::ReadXRefSubsection(InputStreamDevice& device, int64_t& firstObje
     if (objectCount < 0)
         PODOFO_RAISE_ERROR_INFO(PdfErrorCode::ValueOutOfRange, "ReadXRefSubsection: object count is negative");
 
-    m_entries.Enlarge((uint64_t)(firstObject + objectCount));
+    m_entries.Enlarge(static_cast<uint64_t>(firstObject) + static_cast<uint64_t>(objectCount));
 
     // consume all whitespaces
     char ch;

--- a/src/podofo/main/PdfXRefEntry.cpp
+++ b/src/podofo/main/PdfXRefEntry.cpp
@@ -77,13 +77,10 @@ unsigned PdfXRefEntries::GetSize() const
     return (unsigned)m_entries.size();
 }
 
-void PdfXRefEntries::Enlarge(int64_t newSize)
+void PdfXRefEntries::Enlarge(uint64_t newSize)
 {
-    if (newSize < 0)
-        PODOFO_RAISE_ERROR_INFO(PdfErrorCode::ValueOutOfRange, "New size must be positive");
-
     // allow caller to specify a max object count to avoid very slow load times on large documents
-    if (newSize > (int64_t)PdfParser::GetMaxObjectCount())
+    if (newSize > PdfParser::GetMaxObjectCount())
         PODOFO_RAISE_ERROR_INFO(PdfErrorCode::InvalidXRef, "New size is greater than max pdf object count");
 
     if (m_entries.size() >= (size_t)newSize)

--- a/src/podofo/main/PdfXRefEntry.h
+++ b/src/podofo/main/PdfXRefEntry.h
@@ -64,7 +64,7 @@ namespace PoDoFo
          *
          *  \param newSize new size of the vector. It's in64_t to detect possible overflows
          */
-        void Enlarge(int64_t newSize);
+        void Enlarge(uint64_t newSize);
         void Clear();
         PdfXRefEntry& operator[](unsigned index);
         const PdfXRefEntry& operator[](unsigned index) const;

--- a/src/podofo/main/PdfXRefStreamParserObject.cpp
+++ b/src/podofo/main/PdfXRefStreamParserObject.cpp
@@ -115,16 +115,16 @@ void PdfXRefStreamParserObject::parseStream(const int64_t wArray[W_ARRAY_SIZE], 
     size_t offset = 0;
     while (it != indices.end())
     {
-        int64_t firstObj = *it++;
-        int64_t count = *it++;
+        uint64_t firstObj = static_cast<uint64_t>(*it++);
+        uint64_t count = static_cast<uint64_t>(*it++);
 
         if ((offset + count * entryLen) > buffer.size())
             PODOFO_RAISE_ERROR_INFO(PdfErrorCode::InvalidXRefStream, "Invalid count in XRef stream");
 
         m_entries->Enlarge(firstObj + count);
-        for (unsigned index = 0; index < (unsigned)count; index++)
+        for (unsigned index = 0; index < count; index++)
         {
-            unsigned objIndex = (unsigned)firstObj + index;
+            auto objIndex = firstObj + index;
             auto& entry = (*m_entries)[objIndex];
             if (objIndex < m_entries->GetSize() && !entry.Parsed)
                 readXRefStreamEntry(entry, buffer.data() + offset, wArray);


### PR DESCRIPTION
Fuzzing warns about adding these as signed integers first:

```
.../podofo/src/podofo/main/PdfParser.cpp:453:46: runtime error: signed integer overflow: 9223372036854775807 + 1 cannot be represented in type 'int64_t' (aka 'long long')
```

I believe this to be completely benign, but would like to fix it just to avoid a false positive.  (Plus, it actually *might* theoretically cause an issue somewhere some day.)

- [X] Accept to license the library and tools code under the terms
  of the [LGPL 2.0](https://spdx.org/licenses/LGPL-2.0-or-later.html) or later
- [X] Accept to license the library and tools code under the terms
  of the [MPL 2.0](https://spdx.org/licenses/MPL-2.0)
- [X] Accept to license the test code under the terms
  of the [MIT-0](https://spdx.org/licenses/MIT-0.html)
- [X] Read [contributions](https://github.com/podofo/podofo#contributions) guidelines
- [X] Checked coding [style](https://github.com/podofo/podofo/blob/master/CODING-STYLE.md)
- [X] The commits sequence is clean without work in progress/bugged revisions and merge commits. In doubt, [squash](https://github.com/podofo/podofo/wiki/Squash-git-history-guide) the commits and/or rebase master
