### PR TITLE
Handle bad encryption definitions

### DIFF
--- a/test/unit/EncryptTest.cpp
+++ b/test/unit/EncryptTest.cpp
@@ -172,6 +172,29 @@ TEST_CASE("testEnableAlgorithms")
     REQUIRE(testAlgorithms == PdfEncrypt::GetEnabledEncryptionAlgorithms());
 }
 
+TEST_CASE("testBadLength")
+{
+    // avoid segfaulting in openssl call by checking key length
+    PdfObject object;
+    object.GetDictionary().AddKey("Filter", PdfName("Standard"));
+    object.GetDictionary().AddKey("V", static_cast<int64_t>(4L));
+    object.GetDictionary().AddKey("R", static_cast<int64_t>(4L));
+    object.GetDictionary().AddKey("P", static_cast<int64_t>(-44));
+    object.GetDictionary().AddKey("O", PdfString(""));
+    object.GetDictionary().AddKey("U", PdfString(""));
+    object.GetDictionary().AddKey("Length", static_cast<int64_t>(-4));
+
+    try
+    {
+        (void)PdfEncrypt::CreateFromObject(object);
+        REQUIRE(false);
+    }
+    catch (PdfError& error)
+    {
+        REQUIRE(error.GetCode() == PdfErrorCode::InvalidEncryptionDict);
+    }
+}
+
 TEST_CASE("testLoadEncrypedFilePdfParser")
 {
     string tempFile = TestUtils::GetTestOutputFilePath("testLoadEncrypedFilePdfParser.pdf");


### PR DESCRIPTION
E.g., huge or negative `/Length` values cause overflows and segv in openssl calls. Potential security vulnerability.

- [X] Accept to license the library and tools code under the terms
  of the [LGPL 2.0](https://spdx.org/licenses/LGPL-2.0-or-later.html) or later
- [X] Accept to license the library and tools code under the terms
  of the [MPL 2.0](https://spdx.org/licenses/MPL-2.0)
- [X] Accept to license the test code under the terms
  of the [MIT-0](https://spdx.org/licenses/MIT-0.html)
- [X] Read [contributions](https://github.com/podofo/podofo#contributions) guidelines
- [X] Checked coding [style](https://github.com/podofo/podofo/blob/master/CODING-STYLE.md)
- [X] The commits sequence is clean without work in progress/bugged revisions and merge commits. In doubt, [squash](https://github.com/podofo/podofo/wiki/Squash-git-history-guide) the commits and/or rebase master
