### PR TITLE
Make getMultiLineTextAsLines public again

### DIFF
--- a/src/podofo/main/PdfPainter.h
+++ b/src/podofo/main/PdfPainter.h
@@ -499,6 +499,14 @@ public:
      */
     inline PdfObjectStream* GetStream() const { return m_objStream; }
 
+    /** Gets the text divided into individual lines, using the current font and clipping rectangle.
+     *
+     *  \param str the text which should be drawn
+     *  \param width width of the text area
+     *  \param skipSpaces whether the trailing whitespaces should be skipped, so that next line doesn't start with whitespace
+     */
+    std::vector<std::string> getMultiLineTextAsLines(const std::string_view& str, double width, bool skipSpaces);
+
 private:
     // To be called by PdfPainterTextObject
     void BeginText();
@@ -631,14 +639,6 @@ private:
     };
 
 private:
-    /** Gets the text divided into individual lines, using the current font and clipping rectangle.
-     *
-     *  \param str the text which should be drawn
-     *  \param width width of the text area
-     *  \param skipSpaces whether the trailing whitespaces should be skipped, so that next line doesn't start with whitespace
-     */
-    std::vector<std::string> getMultiLineTextAsLines(const std::string_view& str, double width, bool skipSpaces);
-
     void drawTextAligned(const std::string_view& str, double x, double y, double width,
         PdfHorizontalAlignment hAlignment, PdfDrawTextStyle style);
 


### PR DESCRIPTION
For many years we’ve used getMultiLineTextAsLines to break down text into lines (with the current text state), so we know when to advance pages and to be properly able to spread really long text inputs over multiple pages (and show some page break marker etc.)

Since 0.10.x this function is suddenly private, I hereby petition to make this function public again.


--
- [X] Accept to license the library and tools code under the terms
  of the [LGPL 2.0](https://spdx.org/licenses/LGPL-2.0-or-later.html) or later
- [X] Accept to license the library and tools code under the terms
  of the [MPL 2.0](https://spdx.org/licenses/MPL-2.0)
- [X] Accept to license the test code under the terms
  of the [MIT-0](https://spdx.org/licenses/MIT-0.html)
- [X] Read [contributions](https://github.com/podofo/podofo#contributions) guidelines
- [X] Checked coding [style](https://github.com/podofo/podofo/blob/master/CODING-STYLE.md)
- [X] The commits sequence is clean without work in progress/bugged revisions and merge commits. In doubt, [squash](https://github.com/podofo/podofo/wiki/Squash-git-history-guide) the commits and/or rebase master
