### PR TITLE
Fix text underline (and probably strike-through) incompatibility with poppler

### DIFF
--- a/src/podofo/main/PdfPainter.cpp
+++ b/src/podofo/main/PdfPainter.cpp
@@ -366,8 +366,6 @@ void PdfPainter::DrawText(const string_view& str, double x, double y,
 
 void PdfPainter::drawText(const string_view& str, double x, double y, bool isUnderline, bool isStrikeThrough)
 {
-    PoDoFo::WriteOperator_Td(m_stream, x, y);
-
     auto& textState = m_StateStack.Current->TextState;
     auto& font = *textState.Font;
     auto expStr = this->expandTabs(str);
@@ -398,6 +396,8 @@ void PdfPainter::drawText(const string_view& str, double x, double y, bool isUnd
 
         this->restore();
     }
+
+    PoDoFo::WriteOperator_Td(m_stream, x, y);
 
     PoDoFo::WriteOperator_Tj(m_stream, font.GetEncoding().ConvertToEncoded(str),
         !font.GetEncoding().IsSimpleEncoding());

--- a/test/unit/PainterTest.cpp
+++ b/test/unit/PainterTest.cpp
@@ -128,7 +128,6 @@ TEST_CASE("TestPainter3")
     auto expected = R"(q
 BT
 /Ft5 15 Tf
-100 500 Td
 q
 0.75 w
 100 498.5 m
@@ -139,6 +138,7 @@ S
 172.075 503.93 l
 S
 Q
+100 500 Td
 <0001020203040503060207> Tj
 ET
 Q
@@ -214,7 +214,6 @@ BT
 
 ET
 BT
-100 600 Td
 q
 0.75 w
 0.75 w
@@ -222,6 +221,7 @@ q
 137.515 604.35 l
 S
 Q
+100 600 Td
 (Test2) Tj
 ET
 20 20 m


### PR DESCRIPTION
This pull-request fixes an incompatibility with poppler that seems to not restore the position properly with Q (while the official Adobe PDF reader does seem to do that).

Poppler is used in many (!) libraries on Linux, for example Okular uses poppler.

If there isn’t any advantage to putting the Td before the line/strike-through, I’d really recommend switching this to fix the incompatibility.

In Poppler, this simple PDF content

```
q
0 0 0 rg
BT
/Ft4 9 Tf
56.692913 692.935002 Td
q
0.65918 w
56.692913 691.651799 m
71.709027 691.651799 l
S
0.448242 w
Q
<020202> Tj
ET
Q
```

will be rendered like this (screenshotted in Okular)

![image](https://github.com/user-attachments/assets/2de006fa-a966-4597-af47-6f84dbc02803)


With this pull-request the PDF content looks like this

```
q
0 0 0 rg
BT
/Ft4 9 Tf
q
0.65918 w
56.692913 691.651799 m
71.709027 691.651799 l
S
0.448242 w
Q
56.692913 692.935002 Td
<020202> Tj
ET
Q
```

and poppler renders it correctly again (screenshotted in Okular)

![image](https://github.com/user-attachments/assets/aea526c3-fa5d-4dda-a938-cee690c123b9)

This PR fixes the incompatibility in 0.10.x branch, I can create the same pull-request for the master branch if helpful

--

- [X] Accept to license the library and tools code under the terms
  of the [LGPL 2.0](https://spdx.org/licenses/LGPL-2.0-or-later.html) or later
- [X] Accept to license the library and tools code under the terms
  of the [MPL 2.0](https://spdx.org/licenses/MPL-2.0)
- [X] Accept to license the test code under the terms
  of the [MIT-0](https://spdx.org/licenses/MIT-0.html)
- [X] Read [contributions](https://github.com/podofo/podofo#contributions) guidelines
- [X] Checked coding [style](https://github.com/podofo/podofo/blob/master/CODING-STYLE.md)
- [X] The commits sequence is clean without work in progress/bugged revisions and merge commits. In doubt, [squash](https://github.com/podofo/podofo/wiki/Squash-git-history-guide) the commits and/or rebase master
