### PR TITLE
Fix text underline (and probably strike-through) incompatibility with poppler

### DIFF
--- a/src/podofo/main/PdfPainter.cpp
+++ b/src/podofo/main/PdfPainter.cpp
@@ -332,8 +332,6 @@ void PdfPainter::DrawText(const string_view& str, double x, double y,
 
 void PdfPainter::drawText(const string_view& str, double x, double y, bool isUnderline, bool isStrikeThrough)
 {
-    PoDoFo::WriteOperator_Td(m_stream, x, y);
-
     auto& textState = m_StateStack.Current->TextState;
     auto& font = *textState.Font;
     auto expStr = this->expandTabs(str);
@@ -364,6 +362,8 @@ void PdfPainter::drawText(const string_view& str, double x, double y, bool isUnd
 
         this->restore();
     }
+
+    PoDoFo::WriteOperator_Td(m_stream, x, y);
 
     PoDoFo::WriteOperator_Tj(m_stream, font.GetEncoding().ConvertToEncoded(str),
         !font.GetEncoding().IsSimpleEncoding());

--- a/test/unit/PainterTest.cpp
+++ b/test/unit/PainterTest.cpp
@@ -137,7 +137,6 @@ TEST_CASE("TestPainter3")
     auto expected = R"(q
 BT
 /Ft0 15 Tf
-100 500 Td
 q
 0.75 w
 100 498.5 m
@@ -148,6 +147,7 @@ S
 172.075 503.93 l
 S
 Q
+100 500 Td
 <0001020203040503060207> Tj
 ET
 Q
@@ -223,7 +223,6 @@ BT
 
 ET
 BT
-100 600 Td
 q
 0.75 w
 0.75 w
@@ -231,6 +230,7 @@ q
 137.515 604.35 l
 S
 Q
+100 600 Td
 (Test2) Tj
 ET
 20 20 m


### PR DESCRIPTION
Recreate (cherrypick) #196 for master

--

- [X] Accept to license the library and tools code under the terms
  of the [LGPL 2.0](https://spdx.org/licenses/LGPL-2.0-or-later.html) or later
- [X] Accept to license the library and tools code under the terms
  of the [MPL 2.0](https://spdx.org/licenses/MPL-2.0)
- [X] Accept to license the test code under the terms
  of the [MIT-0](https://spdx.org/licenses/MIT-0.html)
- [X] Read [contributions](https://github.com/podofo/podofo#contributions) guidelines
- [X] Checked coding [style](https://github.com/podofo/podofo/blob/master/CODING-STYLE.md)
- [X] The commits sequence is clean without work in progress/bugged revisions and merge commits. In doubt, [squash](https://github.com/podofo/podofo/wiki/Squash-git-history-guide) the commits and/or rebase master
