### PR TITLE
WIP: extract decorateText

### DIFF
--- a/src/podofo/main/PdfPainter.h
+++ b/src/podofo/main/PdfPainter.h
@@ -86,7 +86,7 @@ private:
 
 public:
     /** Apply the given matrix to the current transformation matrix (CTM)
-     * \remarks Corresponds to the PDF 'cm' operator 
+     * \remarks Corresponds to the PDF 'cm' operator
      */
     void ConcatenateTransformationMatrix(const Matrix& matrix);
     void SetLineWidth(double lineWidth);
@@ -100,7 +100,7 @@ public:
     /** Set the color for PDF "stroking" operations
      */
     void SetStrokeColorSpace(PdfColorSpaceInitializer&& color);
-    /** Set the color for PDF "nonstroking" operations 
+    /** Set the color for PDF "nonstroking" operations
      */
     void SetFillColor(const PdfColor& color);
     /** Set the color for PDF "stroking" operations
@@ -666,13 +666,15 @@ private:
     }
 
     void drawTextAligned(const std::string_view& str, double x, double y, double width,
-        PdfHorizontalAlignment hAlignment, PdfDrawTextStyle style);
+        PdfHorizontalAlignment hAlignment);
 
-    void drawText(const std::string_view& str, double x, double y, bool isUnderline, bool isStrikeThrough);
+    void drawText(const std::string_view& str, double x, double y);
 
     void drawMultiLineText(const std::string_view& str, double x, double y, double width, double height,
         PdfHorizontalAlignment hAlignment, PdfVerticalAlignment vAlignment, bool clip, bool skipSpaces,
         PdfDrawTextStyle style);
+
+    void decorateText(const std::string_view& str, double x, double y, PdfDrawTextStyle style);
 
     void setLineWidth(double width);
 


### PR DESCRIPTION
This is a proof of concept. I tested this, and it works, the PDF is now spec compliant for normal DrawText and DrawTextAligned calls.

This is not yet for merging, but for discussion.

Please have a look @ceztko and check if you like the general approach with decorateText

For DrawTextMultiLine the **approach needs to be discussed**, since there are at least two possible ways to implement this, please check the code comment for more info

--

- [X] Accept to license the library and tools code under the terms
  of the [LGPL 2.0](https://spdx.org/licenses/LGPL-2.0-or-later.html) or later
- [X] Accept to license the library and tools code under the terms
  of the [MPL 2.0](https://spdx.org/licenses/MPL-2.0)
- [X] Accept to license the test code under the terms
  of the [MIT-0](https://spdx.org/licenses/MIT-0.html)
- [X] Read [contributions](https://github.com/podofo/podofo#contributions) guidelines
- [X] Checked coding [style](https://github.com/podofo/podofo/blob/master/CODING-STYLE.md)
- [X] The commits sequence is clean without work in progress/bugged revisions and merge commits. In doubt, [squash](https://github.com/podofo/podofo/wiki/Squash-git-history-guide) the commits and/or rebase master
