### PR TITLE
Fix eating of non-space chars in SplitTextAsLines

### DIFF
--- a/src/podofo/main/PdfTextState.cpp
+++ b/src/podofo/main/PdfTextState.cpp
@@ -63,9 +63,11 @@ vector<string> PdfTextState::SplitTextAsLines(const string_view& str, double wid
                         // Skip all spaces at the end of the line
                         while (it != end)
                         {
-                            ch = (char32_t)utf8::next(it, end);
+                            auto nextIt = it;
+                            ch = (char32_t)utf8::next(nextIt, end);
                             if (!utls::IsSpaceLikeChar(ch))
                                 break;
+                            it = nextIt;
                         }
 
                         startOfCurrentWord = it;
@@ -97,9 +99,11 @@ vector<string> PdfTextState::SplitTextAsLines(const string_view& str, double wid
                     // Skip all spaces at the end of the line
                     while (it != end)
                     {
-                        ch = (char32_t)utf8::next(it, end);
+                        auto nextIt = it;
+                        ch = (char32_t)utf8::next(nextIt, end);
                         if (!utls::IsSpaceLikeChar(ch))
                             break;
+                        it = nextIt;
                     }
 
                     startOfCurrentWord = it;


### PR DESCRIPTION
Just noticed this while using the function, seems to eat non-space chars. This seems to fix it.

(Since we need to focus on finishing required features atm I don’t have time to write tests for this or validate the solution further).

Might be related to #111 

--

- [X] Accept to license the library and tools code under the terms
  of the [LGPL 2.0](https://spdx.org/licenses/LGPL-2.0-or-later.html) or later
- [X] Accept to license the library and tools code under the terms
  of the [MPL 2.0](https://spdx.org/licenses/MPL-2.0)
- [X] Accept to license the test code under the terms
  of the [MIT-0](https://spdx.org/licenses/MIT-0.html)
- [X] Read [contributions](https://github.com/podofo/podofo#contributions) guidelines
- [X] Checked coding [style](https://github.com/podofo/podofo/blob/master/CODING-STYLE.md)
- [X] The commits sequence is clean without work in progress/bugged revisions and merge commits. In doubt, [squash](https://github.com/podofo/podofo/wiki/Squash-git-history-guide) the commits and/or rebase master
