### PR TITLE
CodePointSpan: Protect against self-assignment

### DIFF
--- a/src/podofo/main/PdfCharCodeMap.cpp
+++ b/src/podofo/main/PdfCharCodeMap.cpp
@@ -631,6 +631,8 @@ unsigned CodePointSpan::GetSize() const
 
 CodePointSpan& CodePointSpan::operator=(const CodePointSpan& rhs)
 {
+    if (this == &rhs)
+        return *this;
     this->~CodePointSpan();
     auto view = rhs.view();
     if (view.size() > std::size(m_Block.Data))


### PR DESCRIPTION
When using `PdfPage::ExtractTextTo` on PDFs like [this](https://github.com/user-attachments/files/17973374/crash.pdf), the program would occasionally crash with a null pointer dereference. The crash appears to occur on this line:

https://github.com/podofo/podofo/blob/bc19d27c95c42d899bb76118542cc49cbb84d04a/src/podofo/main/PdfCharCodeMap.cpp#L396

Due to how `std::shuffle` is implemented, the above line could result in a swap on the same element of `mappings`, which will cause a self-assignment on the `CodePointSpan` object. This situation is not handled correctly by `CodePointSpan::operator=`. If the data of `CodePointSpan` is sufficiently large to be stored on the heap, self-assignment will invoke the `unique_ptr`'s destructor and reset the pointer to null, causing a subsequent segfault when performing `memcpy` from the data of the same object.

- [x] Accept to license the library and tools code under the terms
  of the [LGPL 2.0](https://spdx.org/licenses/LGPL-2.0-or-later.html) or later
- [x] Accept to license the library and tools code under the terms
  of the [MPL 2.0](https://spdx.org/licenses/MPL-2.0)
- [x] Accept to license the test code under the terms
  of the [MIT-0](https://spdx.org/licenses/MIT-0.html)
- [x] Read [contributions](https://github.com/podofo/podofo#contributions) guidelines
- [x] Checked coding [style](https://github.com/podofo/podofo/blob/master/CODING-STYLE.md)
- [x] The commits sequence is clean without work in progress/bugged revisions and merge commits. In doubt, [squash](https://github.com/podofo/podofo/wiki/Squash-git-history-guide) the commits and/or rebase master