### PR TITLE
PdfPage_TextExtraction: Fix `decodeString` with no font

### DIFF
--- a/src/podofo/main/PdfPage_TextExtraction.cpp
+++ b/src/podofo/main/PdfPage_TextExtraction.cpp
@@ -683,9 +683,9 @@ bool decodeString(const PdfString &str, TextState &state, string &decoded,
             // CHECK-ME: Maybe intrepret them as PdfDocEncoding?
             decoded = str.GetString();
             lengths.resize(decoded.length());
-            positions.reserve(decoded.length());
+            positions.resize(decoded.length());
             for (unsigned i = 0; i < decoded.length(); i++)
-                positions.push_back(i);
+                positions[i] = i;
 
             return true;
         }


### PR DESCRIPTION
With [this](https://github.com/user-attachments/files/17985387/overflow.pdf) PDF, `PdfPage::ExtractTextTo` will trigger a heap buffer overflow in the following statement:

https://github.com/podofo/podofo/blob/e17a7ce4753007b0b6fa5ad25bf42d234e50faec/src/podofo/main/PdfPage_TextExtraction.cpp#L812-L814

In `decodeString`, if the current font is null, the `positions` vector could become much larger than the `lengths` vector because it is not resized properly:

https://github.com/podofo/podofo/blob/e17a7ce4753007b0b6fa5ad25bf42d234e50faec/src/podofo/main/PdfPage_TextExtraction.cpp#L685-L688

In this case, when calling `StatefulString::GetTrimmedEnd` and returning a new `StatefulString`, the vector constructor would attempt to read beyond the end of `Lengths` due to the large size of `StringPositions`.

- [x] Accept to license the library and tools code under the terms
  of the [LGPL 2.0](https://spdx.org/licenses/LGPL-2.0-or-later.html) or later
- [x] Accept to license the library and tools code under the terms
  of the [MPL 2.0](https://spdx.org/licenses/MPL-2.0)
- [x] Accept to license the test code under the terms
  of the [MIT-0](https://spdx.org/licenses/MIT-0.html)
- [x] Read [contributions](https://github.com/podofo/podofo#contributions) guidelines
- [x] Checked coding [style](https://github.com/podofo/podofo/blob/master/CODING-STYLE.md)
- [x] The commits sequence is clean without work in progress/bugged revisions and merge commits. In doubt, [squash](https://github.com/podofo/podofo/wiki/Squash-git-history-guide) the commits and/or rebase master