### PR TITLE
Fix FreeType segfault race condition

### DIFF
--- a/src/podofo/private/FreetypePrivate.cpp
+++ b/src/podofo/private/FreetypePrivate.cpp
@@ -68,7 +68,7 @@ FT_Library FT::GetLibrary()
         FT_Library Library;     // Handle to the freetype library
     };
 
-    static Init init;
+    thread_local Init init;
     return init.Library;
 }
 


### PR DESCRIPTION
The FreeType library instance is not multi-thread safe, you can easily test this by generating a PDF with loaded fonts in multiple threads (segfault is pretty instant with 8 threads) at the same time.



--

- [X] Accept to license the library and tools code under the terms
  of the [LGPL 2.0](https://spdx.org/licenses/LGPL-2.0-or-later.html) or later
- [X] Accept to license the library and tools code under the terms
  of the [MPL 2.0](https://spdx.org/licenses/MPL-2.0)
- [X] Accept to license the test code under the terms
  of the [MIT-0](https://spdx.org/licenses/MIT-0.html)
- [X] Read [contributions](https://github.com/podofo/podofo#contributions) guidelines
- [X] Checked coding [style](https://github.com/podofo/podofo/blob/master/CODING-STYLE.md)
- [X] The commits sequence is clean without work in progress/bugged revisions and merge commits. In doubt, [squash](https://github.com/podofo/podofo/wiki/Squash-git-history-guide) the commits and/or rebase master
