### PR TITLE
PdfPage: Add abort check in PdfPage::ExtractTextTo

### DIFF
--- a/src/podofo/main/PdfPage.h
+++ b/src/podofo/main/PdfPage.h
@@ -38,8 +38,7 @@ struct PODOFO_API PdfTextExtractParams final
     nullable<Rect> ClipRect;
     PdfTextExtractFlags Flags = PdfTextExtractFlags::None;
 
-    std::function<bool(int read_cnt, void *d)> AbortCheck = nullptr;
-    void *AbortCheckData = nullptr;
+    std::function<bool(int read_cnt)> AbortCheck = nullptr;
 };
 
 template <typename TField>

--- a/src/podofo/main/PdfPage.h
+++ b/src/podofo/main/PdfPage.h
@@ -37,6 +37,9 @@ struct PODOFO_API PdfTextExtractParams final
 {
     nullable<Rect> ClipRect;
     PdfTextExtractFlags Flags = PdfTextExtractFlags::None;
+
+    std::function<bool(int read_cnt, void *d)> AbortCheck = nullptr;
+    void *AbortCheckData = nullptr;
 };
 
 template <typename TField>

--- a/src/podofo/main/PdfPage_TextExtraction.cpp
+++ b/src/podofo/main/PdfPage_TextExtraction.cpp
@@ -211,7 +211,7 @@ void PdfPage::ExtractTextTo(vector<PdfTextEntry>& entries, const string_view& pa
         // Check for an abort
         read_cnt += 1;
         if (read_cnt % 100 == 0) {
-          if (params.AbortCheck && params.AbortCheck(read_cnt, params.AbortCheckData)) {
+          if (params.AbortCheck && params.AbortCheck(read_cnt)) {
             break;
           }
         }

--- a/src/podofo/main/PdfPage_TextExtraction.cpp
+++ b/src/podofo/main/PdfPage_TextExtraction.cpp
@@ -205,8 +205,17 @@ void PdfPage::ExtractTextTo(vector<PdfTextEntry>& entries, const string_view& pa
     vector<double> lengths;
     vector<unsigned> positions;
     string decoded;
+    unsigned read_cnt = 0;
     while (reader.TryReadNext(content))
     {
+        // Check for an abort
+        read_cnt += 1;
+        if (read_cnt % 100 == 0) {
+          if (params.AbortCheck && params.AbortCheck(read_cnt, params.AbortCheckData)) {
+            break;
+          }
+        }
+
         switch (content.Type)
         {
             case PdfContentType::Operator:
@@ -1130,7 +1139,7 @@ void splitStringBySpaces(vector<StatefulString> &separatedStrings, const Statefu
     unsigned upperPosLim = (unsigned)str.String.length();
     unsigned lowerPosIndex;
     unsigned upperPosLimIndex;
-    
+
     auto pushString = [&]() {
         getSubstringIndices(str.StringPositions, lowerPos, upperPosLim, lowerPosIndex, upperPosLimIndex);
         double length = 0;

--- a/test/unit/TextExtraction.cpp
+++ b/test/unit/TextExtraction.cpp
@@ -75,3 +75,21 @@ TEST_CASE("TextExtraction3")
     auto str = PdfString::FromHexData("00205168770173af5c9b592971366c147ba17f515c1a672a6210578bff0c4e1c90e890e852065efa8bbe6ede540eff0c7ba17f517f3a4e4f7edf4e0089c45212ff0c7ba190537ba15f8430018bbe8ba1538b529b53c25dee4e0d9f50ff0c77015185652f5e72");
     REQUIRE(font->GetEncoding().ConvertToUtf8(str) == " 全省环岛天然气管网尚未成型，东部部分建设滞后，管网缺乏统一规划，管道管径、设计压力参差不齐，省内支干");
 }
+
+TEST_CASE("TextExtraction4")
+{
+    PdfMemDocument doc;
+    doc.Load(TestUtils::GetTestInputFilePath("TextExtraction1.pdf"));
+
+    auto& page = doc.GetPages().GetPageAt(0);
+    vector<PdfTextEntry> entries;
+    bool abort = false;
+    PdfTextExtractParams params = {};
+    params.AbortCheck = [&](int read_cnt) {
+        abort = read_cnt > 2;
+        return abort;
+    };
+    page.ExtractTextTo(entries, params);
+
+    REQUIRE(abort);
+}


### PR DESCRIPTION
Avoid function that loop endlessly or take too long

When using `PoDoFo` to process some abnormal or non-compliant PDF files, it may result in an infinite loop. The same issue occurs when I test these abnormal PDFs using `Poppler`. Therefore, I referred to the approach used by `Poppler` and added an abort check callback function, allowing the caller to control the exit from `PdfPage::ExtractTextTo`. 

- [x] Accept to license the library and tools code under the terms
  of the [LGPL 2.0](https://spdx.org/licenses/LGPL-2.0-or-later.html) or later
- [x] Accept to license the library and tools code under the terms
  of the [MPL 2.0](https://spdx.org/licenses/MPL-2.0)
- [x] Accept to license the test code under the terms
  of the [MIT-0](https://spdx.org/licenses/MIT-0.html)
- [x] Read [contributions](https://github.com/podofo/podofo#contributions) guidelines
- [x] Checked coding [style](https://github.com/podofo/podofo/blob/master/CODING-STYLE.md)
- [x] The commits sequence is clean without work in progress/bugged revisions and merge commits. In doubt, [squash](https://github.com/podofo/podofo/wiki/Squash-git-history-guide) the commits and/or rebase master
