### PR TITLE
Add basic font data to PdfTextEntry 

### DIFF
--- a/src/podofo/main/PdfPage.h
+++ b/src/podofo/main/PdfPage.h
@@ -31,6 +31,8 @@ struct PODOFO_API PdfTextEntry final
     double Y = -1;
     double Length = -1;
     nullable<Rect> BoundingBox;
+    std::string FontName; 
+    double FontSize = -1; 
 };
 
 /** A structure with status progress attributes of certain operations

--- a/src/podofo/main/PdfPage_TextExtraction.cpp
+++ b/src/podofo/main/PdfPage_TextExtraction.cpp
@@ -566,6 +566,12 @@ void addEntryChunk(vector<PdfTextEntry> &textEntries, StringChunkList &chunks, c
     unsigned lowerIndex = 0;
     unsigned upperIndexLimit = (unsigned)glyphAddresses.size();
     auto textState = firstStr.State;
+    std::string fontName;
+    double fontSize = -1;
+    if (textState.PdfState.Font)
+        fontName = textState.PdfState.Font->GetName();
+    fontSize = textState.PdfState.FontSize;
+
     if (pattern.length() != 0)
     {
         PODOFO_INVARIANT(utls::IsValidUtf8String(pattern));
@@ -657,14 +663,14 @@ void addEntryChunk(vector<PdfTextEntry> &textEntries, StringChunkList &chunks, c
     if (rotation == nullptr || options.RawCoordinates)
     {
         textEntries.push_back(PdfTextEntry{ str, pageIndex,
-            strPosition.X, strPosition.Y, strLength, bbox });
+            strPosition.X, strPosition.Y, strLength, bbox, fontName, fontSize });
     }
     else
     {
         Vector2 rawp(strPosition.X, strPosition.Y);
         auto p_1 = rawp * (*rotation);
         textEntries.push_back(PdfTextEntry{ str, pageIndex,
-            p_1.X, p_1.Y, strLength, bbox });
+            p_1.X, p_1.Y, strLength, bbox, fontName, fontSize });
     }
 
     chunks.clear();

--- a/test/unit/TextExtraction.cpp
+++ b/test/unit/TextExtraction.cpp
@@ -93,3 +93,15 @@ TEST_CASE("TextExtraction4")
 
     REQUIRE(abort);
 }
+
+TEST_CASE("TextExtraction5")
+{
+    PdfMemDocument doc;
+    doc.Load(TestUtils::GetTestInputFilePath("TextExtraction2.pdf"));
+    auto& page = doc.GetPages().GetPageAt(0);
+    vector<PdfTextEntry> entries;
+    page.ExtractTextTo(entries);
+    REQUIRE(entries[0].Text == "Test text");
+    REQUIRE(entries[0].FontName == "Helvetica"); 
+    REQUIRE(entries[0].FontSize == 12.0);
+}


### PR DESCRIPTION
- [x] Accept to license the library and tools code under the terms
  of the [LGPL 2.0](https://spdx.org/licenses/LGPL-2.0-or-later.html) or later
- [x] Accept to license the library and tools code under the terms
  of the [MPL 2.0](https://spdx.org/licenses/MPL-2.0)
- [x] Accept to license the test code under the terms
  of the [MIT-0](https://spdx.org/licenses/MIT-0.html)
- [x] Read [contributions](https://github.com/podofo/podofo#contributions) guidelines
- [x] Checked coding [style](https://github.com/podofo/podofo/blob/master/CODING-STYLE.md)
- [x] The commits sequence is clean without work in progress/bugged revisions and merge commits. In doubt, [squash](https://github.com/podofo/podofo/wiki/Squash-git-history-guide) the commits and/or rebase master


I was recently working on a project that required extracting text from a PDF then validating it's font, and found it is really difficult to actually get the font of text extracted by [PdfPage::ExtractTextTo](https://github.com/podofo/podofo/blob/587c7ed24f84a5614098e65128da16d5bb11e983/src/podofo/main/PdfPage_TextExtraction.cpp#L195)
I couldn't find a clear way to do this and realized that getting the basic font data of text you extract easily is likely a feature that many other people would use. So I created this PR. 

I wrote a unit test in the corresponding testing file and tested with an existing testing pdf then reviewed the font in PDF-XChange. For me, all tests passed after adding my changes and I hope my code fits your guys standards. 

Below I provided screenshots to the font names in XChange that match the font name in the unit test. 
![image](https://github.com/user-attachments/assets/4c02fd1c-85e5-4ba9-8e7f-ee6159954e0c)
![image](https://github.com/user-attachments/assets/0d3118d0-19e4-4e5a-99ad-976c55a68e42)
