### PR TITLE
`'` and `"` mean “`T*`, and *then* Tj”

### DIFF
--- a/src/podofo/main/PdfPage_TextExtraction.cpp
+++ b/src/podofo/main/PdfPage_TextExtraction.cpp
@@ -317,17 +317,17 @@ void PdfPage::ExtractTextTo(vector<PdfTextEntry>& entries, const string_view& pa
                             context.States.Current->PdfState.WordSpacing = content->Stack[2].GetReal();
                         }
 
+                        if (content->Operator == PdfOperator::Quote
+                            || content->Operator == PdfOperator::DoubleQuote)
+                        {
+                            context.TStar_Operator();
+                        }
+
                         if (decodeString(str, *context.States.Current, decoded, lengths, positions)
                             && decoded.length() != 0)
                         {
                             context.PushString(StatefulString(std::move(decoded), *context.States.Current,
                                 std::move(lengths), std::move(positions)), true);
-                        }
-
-                        if (content->Operator == PdfOperator::Quote
-                            || content->Operator == PdfOperator::DoubleQuote)
-                        {
-                            context.TStar_Operator();
                         }
 
                         break;

--- a/test/unit/TextExtraction.cpp
+++ b/test/unit/TextExtraction.cpp
@@ -93,3 +93,27 @@ TEST_CASE("TextExtraction4")
 
     REQUIRE(abort);
 }
+
+TEST_CASE("TextExtraction5")
+{
+    // Extraction with quote operators
+    PdfMemDocument doc;
+    doc.Load(TestUtils::GetTestInputFilePath("TextExtraction5.pdf"));
+    auto& page = doc.GetPages().GetPageAt(0);
+    vector<PdfTextEntry> entries;
+    page.ExtractTextTo(entries);
+    ASSERT_EQUAL(entries.size(),4);
+    REQUIRE(entries[0].Text == "Line 1");
+    ASSERT_EQUAL(entries[0].X, 10.0);
+    ASSERT_EQUAL(entries[0].Y, 112.0);
+    REQUIRE(entries[1].Text == "Line 2");
+    ASSERT_EQUAL(entries[1].X, 10.0);
+    ASSERT_EQUAL(entries[1].Y, 94.0);
+
+    REQUIRE(entries[2].Text == "Paragraph 2");
+    ASSERT_EQUAL(entries[2].X, 10.0);
+    ASSERT_EQUAL(entries[2].Y, 64.0);
+    REQUIRE(entries[3].Text == "Para 2, Line 2");
+    ASSERT_EQUAL(entries[3].X, 10.0);
+    ASSERT_EQUAL(entries[3].Y, 46.0);
+}


### PR DESCRIPTION
Fix the order of operations for the quote and double-quote operators: They ahould start a new line first, and then parse the text.

Fixes #278

- [X] Accept to license the library and tools code under the terms
  of the [LGPL 2.0](https://spdx.org/licenses/LGPL-2.0-or-later.html) or later
- [X] Accept to license the library and tools code under the terms
  of the [MPL 2.0](https://spdx.org/licenses/MPL-2.0)
- [X] Accept to license the test code under the terms
  of the [MIT-0](https://spdx.org/licenses/MIT-0.html)
- [X] Read [contributions](https://github.com/podofo/podofo#contributions) guidelines
- [X] Checked coding [style](https://github.com/podofo/podofo/blob/master/CODING-STYLE.md)
- [X] The commits sequence is clean without work in progress/bugged revisions and merge commits. In doubt, [squash](https://github.com/podofo/podofo/wiki/Squash-git-history-guide) the commits and/or rebase master
