### PR TITLE
Fix incorrect difference calculation when PDF object IDs are non-contiguous

### DIFF
--- a/src/podofo/main/PdfDocument.cpp
+++ b/src/podofo/main/PdfDocument.cpp
@@ -15,6 +15,21 @@
 using namespace std;
 using namespace PoDoFo;
 
+inline unsigned getDifference(PdfIndirectObjectList& m_Objects) {
+    unsigned maxObjectId = 0;
+
+    for (auto& obj : m_Objects) {
+        maxObjectId = std::max(maxObjectId, obj->GetIndirectReference().ObjectNumber());
+    }
+
+    for (auto& ref : m_Objects.GetFreeObjects()) {
+        maxObjectId = std::max(maxObjectId, ref.ObjectNumber());
+    }
+
+    unsigned difference = maxObjectId + 1;
+    return difference;
+}
+
 PdfDocument::PdfDocument(bool empty) :
     m_Objects(*this),
     m_Metadata(*this),
@@ -106,7 +121,7 @@ void PdfDocument::append(const PdfDocument& doc, bool appendAll)
     // but in this way free objects should be already taken into account. We'll eventually fix it by not
     // relying on computing a static difference between inserted objects and objects being inserted but just
     // inserting objects normally and remapping them with a support map
-    unsigned difference = static_cast<unsigned>(m_Objects.GetObjectCount() + m_Objects.GetFreeObjects().size());
+    unsigned difference = getDifference(m_Objects);
 
     // create all free objects again, to have a clean free object list
     for (auto& ref : doc.GetObjects().GetFreeObjects())
@@ -192,7 +207,7 @@ void PdfDocument::InsertDocumentPageAt(unsigned atIndex, const PdfDocument& doc,
     // but in this way free objects should be already taken into account. We'll eventually fix it by not
     // relying on computing a static difference between inserted objects and objects being inserted but just
     // inserting objects normally and remapping them with a support map
-    unsigned difference = static_cast<unsigned>(m_Objects.GetObjectCount() + m_Objects.GetFreeObjects().size());
+    unsigned difference = getDifference(m_Objects);
 
     // create all free objects again, to have a clean free object list
     for (auto& freeObj : doc.GetObjects().GetFreeObjects())
@@ -355,7 +370,7 @@ Rect PdfDocument::FillXObjectFromPage(PdfXObjectForm& xobj, const PdfPage& page,
         // but in this way free objects should be already taken into account. We'll eventually fix it by not
         // relying on computing a static difference between inserted objects and objects being inserted but just
         // inserting objects normally and remapping them with a support map
-        difference = static_cast<unsigned>(m_Objects.GetObjectCount() + m_Objects.GetFreeObjects().size());
+        difference = getDifference(m_Objects);
         append(sourceDoc, false);
     }
 


### PR DESCRIPTION
# Summary
This PR updates the logic used to compute difference, which previously relied on the total number of objects plus free objects. That approach implicitly assumed that PDF object numbers are sequential, which is not guaranteed by the PDF specification. As a result, PDFs containing non-contiguous or sparse object numbers could lead to incorrect calculations and potential ID conflicts.

# Reference
According to the PDF 1.7 / ISO 32000-1 specification:
- Object numbers are non-negative integers assigned to indirect objects, and they are not required to be sequential. (Section 7.3.10 – Indirect objects).
- Readers rely on the cross-reference table to locate objects, not on continuity of numbering (Section 7.5.4 – Cross-reference table).
- Incremental updates frequently introduce new object numbers, resulting in gaps (Section 7.5.6 – Incremental updates).

# Example
When merging PDF B into PDF A:

PDF A
```
1 0 obj
2 0 obj
4 0 obj
```

PDF B
```
1 0 obj
2 0 obj
50 0 obj
200 0 obj
```

Using the old logic, the computed difference before merging PDF B into PDF A would be:
```
difference = object_count + free_count = 3
```

When applying this offset to PDF B, the first object becomes:
```
1 + 3 = 4
```

However, 4 already exists in PDF A.
This results in a duplicate object ID, causing a conflict during the merge process.

- [x] Accept to license the library and tools code under the terms
  of the [LGPL 2.0](https://spdx.org/licenses/LGPL-2.0-or-later.html) or later
- [x] Accept to license the library and tools code under the terms
  of the [MPL 2.0](https://spdx.org/licenses/MPL-2.0)
- [x] Accept to license the test code under the terms
  of the [MIT-0](https://spdx.org/licenses/MIT-0.html)
- [x] Read [contributions](https://github.com/podofo/podofo#contributions) guidelines
- [x] Checked coding [style](https://github.com/podofo/podofo/blob/master/CODING-STYLE.md)
- [x] The commits sequence is clean without work in progress/bugged revisions and merge commits. In doubt, [squash](https://github.com/podofo/podofo/wiki/Squash-git-history-guide) the commits and/or rebase master
