### PR TITLE
Added the parser.h include from libxml

### DIFF
--- a/src/podofo/private/XMPUtils.h
+++ b/src/podofo/private/XMPUtils.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include "XmlUtils.h"
-#include <libxml/parser.h>
 #include <podofo/main/PdfMetadataStore.h>
 
 namespace PoDoFo

--- a/src/podofo/private/XmlUtils.h
+++ b/src/podofo/private/XmlUtils.h
@@ -10,6 +10,7 @@
 #include <functional>
 #include <libxml/tree.h>
 #include <libxml/xmlerror.h>
+#include <libxml/parser.h>
 #include <podofo/auxiliary/nullable.h>
 
 // Cast macro that keep or enforce const to use


### PR DESCRIPTION
I was getting errors when compiling on macOS 15.7.2 with Xcode 26.1 and linking to libxml 2.13.0.  Errors were :

```
[ 30%] Building C object 3rdparty/CMakeFiles/podofo_3rdparty.dir/afdko/source/t1read/t1read.c.o
/Users/nick/Documents/GitHub/BaseElements-Plugin-Libraries/output/platforms/macos-arm64_x86_64/src/podofo/src/podofo/private/XMPUtils.cpp:726:15: error: use of undeclared identifier 'xmlParseInNodeContext'
  726 |     auto rc = xmlParseInNodeContext(description, extension.data(), (int)extension.size(), 0, &newNode);
      |               ^
```

The notable bit being:

/podofo/private/XMPUtils.cpp:726:15: error: use of undeclared identifier 'xmlParseInNodeContext'

which I looked up xmlParseInNodeContext in libxml, and found it needs the parser.h header file included.  After that I got no more errors.



Fixes an issue with error: use of undeclared identifier 'xmlParseInNodeContext' =

- [x] Accept to license the library and tools code under the terms
  of the [LGPL 2.0](https://spdx.org/licenses/LGPL-2.0-or-later.html) or later
- [x] Accept to license the library and tools code under the terms
  of the [MPL 2.0](https://spdx.org/licenses/MPL-2.0)
- [x] Accept to license the test code under the terms
  of the [MIT-0](https://spdx.org/licenses/MIT-0.html)
- [x] Read [contributions](https://github.com/podofo/podofo#contributions) guidelines
- [x] Checked coding [style](https://github.com/podofo/podofo/blob/master/CODING-STYLE.md)
- [x] The commits sequence is clean without work in progress/bugged revisions and merge commits. In doubt, [squash](https://github.com/podofo/podofo/wiki/Squash-git-history-guide) the commits and/or rebase master
