### PR TITLE
Fix link issues when client links against PoDoFo and pdfium

### DIFF
--- a/3rdparty/pdfium/core/fxcodec/fax/faxmodule.cpp
+++ b/3rdparty/pdfium/core/fxcodec/fax/faxmodule.cpp
@@ -16,7 +16,7 @@
 #include <pdfium/pdfium_shim.h>
 #include <pdfium/core/fxcodec/scanlinedecoder.h>
 
-namespace fxcodec {
+namespace PoDoFo_fxcodec {
 
 namespace {
 

--- a/3rdparty/pdfium/core/fxcodec/fax/faxmodule.h
+++ b/3rdparty/pdfium/core/fxcodec/fax/faxmodule.h
@@ -13,7 +13,7 @@
 
 #include <pdfium/third_party/base/span.h>
 
-namespace fxcodec {
+namespace PoDoFo_fxcodec {
 
 class ScanlineDecoder;
 
@@ -46,6 +46,6 @@ class FaxModule {
 
 }  // namespace fxcodec
 
-using FaxModule = fxcodec::FaxModule;
+using FaxModule = PoDoFo_fxcodec::FaxModule;
 
 #endif  // CORE_FXCODEC_FAX_FAXMODULE_H_

--- a/3rdparty/pdfium/core/fxcodec/scanlinedecoder.cpp
+++ b/3rdparty/pdfium/core/fxcodec/scanlinedecoder.cpp
@@ -8,7 +8,7 @@
 
 #include <pdfium/core/fxcrt/pauseindicator_iface.h>
 
-namespace fxcodec {
+namespace PoDoFo_fxcodec {
 
 ScanlineDecoder::ScanlineDecoder() : ScanlineDecoder(0, 0, 0, 0, 0, 0, 0) {}
 
@@ -47,7 +47,7 @@ pdfium::span<const uint8_t> ScanlineDecoder::GetScanline(int line) {
   return m_pLastScanline;
 }
 
-bool ScanlineDecoder::SkipToScanline(int line, PauseIndicatorIface* pPause) {
+bool ScanlineDecoder::SkipToScanline(int line, PoDoFo_PauseIndicatorIface* pPause) {
   if (m_NextLine == line || m_NextLine == line + 1)
     return false;
 

--- a/3rdparty/pdfium/core/fxcodec/scanlinedecoder.h
+++ b/3rdparty/pdfium/core/fxcodec/scanlinedecoder.h
@@ -11,9 +11,9 @@
 
 #include <pdfium/third_party/base/span.h>
 
-class PauseIndicatorIface;
+class PoDoFo_PauseIndicatorIface;
 
-namespace fxcodec {
+namespace PoDoFo_fxcodec {
 
 class ScanlineDecoder {
  public:
@@ -28,7 +28,7 @@ class ScanlineDecoder {
   virtual ~ScanlineDecoder();
 
   pdfium::span<const uint8_t> GetScanline(int line);
-  bool SkipToScanline(int line, PauseIndicatorIface* pPause);
+  bool SkipToScanline(int line, PoDoFo_PauseIndicatorIface* pPause);
 
   int GetWidth() const { return m_OutputWidth; }
   int GetHeight() const { return m_OutputHeight; }
@@ -54,6 +54,6 @@ class ScanlineDecoder {
 
 }  // namespace fxcodec
 
-using ScanlineDecoder = fxcodec::ScanlineDecoder;
+using ScanlineDecoder = PoDoFo_fxcodec::ScanlineDecoder;
 
 #endif  // CORE_FXCODEC_SCANLINEDECODER_H_

--- a/3rdparty/pdfium/core/fxcrt/pauseindicator_iface.h
+++ b/3rdparty/pdfium/core/fxcrt/pauseindicator_iface.h
@@ -7,9 +7,9 @@
 #ifndef CORE_FXCRT_PAUSEINDICATOR_IFACE_H_
 #define CORE_FXCRT_PAUSEINDICATOR_IFACE_H_
 
-class PauseIndicatorIface {
+class PoDoFo_PauseIndicatorIface {
  public:
-  virtual ~PauseIndicatorIface() = default;
+  virtual ~PoDoFo_PauseIndicatorIface() = default;
   virtual bool NeedToPauseNow() = 0;
 };
 


### PR DESCRIPTION
I require rendering in my app, which PoDoFo doesn't provide. As such I was thinking about using pdfium, but I can currently not link against PoDoFo and pdfium, since PoDoFo vendors parts of pdfium. Unfortunately these parts are even internal to pdfium, so I can't just unvendor them via my package manager.

I also wanna note here that I am pretty unsure if you're really allowed to ship this code from pdfium. Looking at its license it seems to me you're essentially imposing pretty strict requirements onto PoDoFo users, but it's not obvious to them that PoDoFo comes with such a license through dependencies.

See this excerpt from the pdfium license:
> // * Redistributions in binary form must reproduce the above
// copyright notice, this list of conditions and the following disclaimer
// in the documentation and/or other materials provided with the
// distribution.

I'm not very knowledgeable about license issues, so please to explain how my thinking is wrong here.

- [x] Accept to license the library and tools code under the terms
  of the [LGPL 2.0](https://spdx.org/licenses/LGPL-2.0-or-later.html) or later
- [x] Accept to license the library and tools code under the terms
  of the [MPL 2.0](https://spdx.org/licenses/MPL-2.0)
- [x] Accept to license the test code under the terms
  of the [MIT-0](https://spdx.org/licenses/MIT-0.html)
- [x] Read [contributions](https://github.com/podofo/podofo#contributions) guidelines
- [x] Checked coding [style](https://github.com/podofo/podofo/blob/master/CODING-STYLE.md)
- [x] The commits sequence is clean without work in progress/bugged revisions and merge commits. In doubt, [squash](https://github.com/podofo/podofo/wiki/Squash-git-history-guide) the commits and/or rebase master
