### PR TITLE
Fix segfault in PdfAnnotationActionBase::getAction

### DIFF
--- a/src/podofo/main/PdfAnnotationActionBase.cpp
+++ b/src/podofo/main/PdfAnnotationActionBase.cpp
@@ -73,6 +73,8 @@ nullable<PdfAction&> PdfAnnotationActionBase::getAction()
             unique_ptr<PdfAction> action;
             if (PdfAction::TryCreateFromObject(*obj, action))
                 m_Action = std::move(action);
+            else
+                m_Action *= nullptr;
         }
     }
 

--- a/test/unit/CorruptedTest.cpp
+++ b/test/unit/CorruptedTest.cpp
@@ -18,3 +18,21 @@ TEST_CASE("TestFixInvalidCrossReferenceTable")
     utls::ReadTo(buff, TestUtils::GetTestOutputFilePath("TestFixInvalidCrossReferenceTable.pdf"));
     REQUIRE(ssl::ComputeMD5Str(buff) == "FF980936FDE894F4495DDEC7C13AF4F4");
 }
+
+TEST_CASE("TestMalformedAnnotationAction")
+{
+    // Test that a PDF with a malformed action in a Link annotation does not
+    // crash when accessing the annotation's action.
+    PdfMemDocument doc;
+    doc.Load(TestUtils::GetTestInputFilePath("TestMalformedAnnotationAction.pdf"));
+
+    auto& page = doc.GetPages().GetPageAt(0);
+    REQUIRE(page.GetAnnotations().GetCount() == 1);
+
+    auto& annot = page.GetAnnotations().GetAnnotAt(0);
+    REQUIRE(annot.GetType() == PdfAnnotationType::Link);
+
+    auto& linkAnnot = static_cast<PdfAnnotationLink&>(annot);
+    auto action = linkAnnot.GetAction();
+    REQUIRE(action == nullptr);
+}


### PR DESCRIPTION
If `PdfAction::TryCreateFromObject` fails, `m_Action` is never set, so it has undefined behavior, which leads to a segfault when dereferencing `m_Action`.

```bash
$ wget https://github.com/mtlynch/podofo-resources/raw/9c4a22ee8170c560ec6055581bb2c1bce6b08068/TestMalformedAnnotationAction.pdf
...
$ podofopdfinfo TestMalformedAnnotationAction.pdf 
Document Info
-------------
        File: TestMalformedAnnotationAction.pdf
        PDF Version: 1.7
        Page Count: 1
        Page Size: 1 x 1 pts

        Tagged: No
        Encrypted: No
        Printing Allowed: Yes
        Modification Allowed: Yes
        Copy&Paste Allowed: Yes
        Add/Modify Annotations Allowed: Yes
        Fill&Sign Allowed: Yes
        Accessibility Allowed: Yes
        Document Assembly Allowed: Yes
        High Quality Print Allowed: Yes

Classic Metadata
----------------
No info dictionary in this PDF file!

Page Info
---------
Page Count: 1
Page 0:
->Internal Number:1
->Object Number:3 0 R
        MediaBox: [ 0 0 1 1]
        Rotation: 0
        # of Annotations: 1

        Annotation 0
                Type: Link
                Flags: 0
                Rect: [ 0 0 0 0]
Segmentation fault         (core dumped)
```


The fix is to set `m_Action` explicitly to `nullptr` when `PdfAction::TryCreateFromObject` fails.

- [x] Accept to license the library and tools code under the terms
  of the [LGPL 2.0](https://spdx.org/licenses/LGPL-2.0-or-later.html) or later
- [x] Accept to license the library and tools code under the terms
  of the [MPL 2.0](https://spdx.org/licenses/MPL-2.0)
- [x] Accept to license the test code under the terms
  of the [MIT-0](https://spdx.org/licenses/MIT-0.html)
- [x] Read [contributions](https://github.com/podofo/podofo#contributions) guidelines
- [x] Checked coding [style](https://github.com/podofo/podofo/blob/master/CODING-STYLE.md)
- [x] The commits sequence is clean without work in progress/bugged revisions and merge commits. In doubt, [squash](https://github.com/podofo/podofo/wiki/Squash-git-history-guide) the commits and/or rebase master
