### PR TITLE
Update GitHub Actions workflows to use latest action versions

### DIFF
--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -2,7 +2,7 @@ name: build-documentation
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   workflow_dispatch:
 
 permissions:
@@ -28,10 +28,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
 
       - name: Install Doxygen
         run: |
@@ -45,7 +45,7 @@ jobs:
         run: doxygen "${{github.workspace}}/build/Doxyfile"
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: "${{github.workspace}}/build/doxygen"
 
@@ -56,7 +56,6 @@ jobs:
       name: github-pages
       url: ${{steps.deployment.outputs.page_url}}
     steps:
-
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -2,7 +2,7 @@ name: build-documentation
 
 on:
   push:
-    branches: [master]
+    branches: [ master ]
   workflow_dispatch:
 
 permissions:
@@ -56,6 +56,7 @@ jobs:
       name: github-pages
       url: ${{steps.deployment.outputs.page_url}}
     steps:
+
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v5

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -2,15 +2,15 @@ name: build-linux
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
   workflow_dispatch:
     inputs:
       ctestArgs:
-        description: 'CTest arguments'
+        description: "CTest arguments"
       runCodeQL:
-        description: 'Run CodeQL analysis'
+        description: "Run CodeQL analysis"
         type: boolean
 
 env:
@@ -18,39 +18,39 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     strategy:
       matrix:
-        language: [ 'cpp' ]
+        language: ["cpp"]
 
     steps:
-    - uses: actions/checkout@v2
-      with:
+      - uses: actions/checkout@v6
+        with:
           submodules: true
 
-    - name: Initialize CodeQL
-      if: ${{ github.event.inputs.runCodeQL }}
-      uses: github/codeql-action/init@v2
-      with:
-        languages: ${{ matrix.language }}
-        config-file: ./.github/codeql/codeql-config.yml
+      - name: Initialize CodeQL
+        if: ${{ github.event.inputs.runCodeQL }}
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          config-file: ./.github/codeql/codeql-config.yml
 
-    - name: Install deps
-      run: sudo apt-get install -y libfontconfig1-dev libfreetype-dev libxml2-dev libssl-dev libjpeg-dev libpng-dev libtiff-dev
+      - name: Install deps
+        run: sudo apt-get install -y libfontconfig1-dev libfreetype-dev libxml2-dev libssl-dev libjpeg-dev libpng-dev libtiff-dev
 
-    - name: Configure CMake
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+      - name: Configure CMake
+        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
 
-    - name: Build
-      run: cmake --build ${{github.workspace}}/build
+      - name: Build
+        run: cmake --build ${{github.workspace}}/build
 
-    - name: Test
-      working-directory: ${{github.workspace}}/build
-      run: ctest ${{ github.event.inputs.ctestArgs }}
+      - name: Test
+        working-directory: ${{github.workspace}}/build
+        run: ctest ${{ github.event.inputs.ctestArgs }}
 
-    - name: Perform CodeQL Analysis
-      if: ${{ github.event.inputs.runCodeQL }}
-      uses: github/codeql-action/analyze@v2
-      with:
-        category: "/language:${{matrix.language}}"
+      - name: Perform CodeQL Analysis
+        if: ${{ github.event.inputs.runCodeQL }}
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{matrix.language}}"

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -2,15 +2,15 @@ name: build-linux
 
 on:
   push:
-    branches: [master]
+    branches: [ master ]
   pull_request:
-    branches: [master]
+    branches: [ master ]
   workflow_dispatch:
     inputs:
       ctestArgs:
-        description: "CTest arguments"
+        description: 'CTest arguments'
       runCodeQL:
-        description: "Run CodeQL analysis"
+        description: 'Run CodeQL analysis'
         type: boolean
 
 env:
@@ -22,35 +22,35 @@ jobs:
 
     strategy:
       matrix:
-        language: ["cpp"]
+        language: [ 'cpp' ]
 
     steps:
-      - uses: actions/checkout@v6
-        with:
+    - uses: actions/checkout@v6
+      with:
           submodules: true
 
-      - name: Initialize CodeQL
-        if: ${{ github.event.inputs.runCodeQL }}
-        uses: github/codeql-action/init@v4
-        with:
+    - name: Initialize CodeQL
+      if: ${{ github.event.inputs.runCodeQL }}
+      uses: github/codeql-action/init@v4
+      with:
           languages: ${{ matrix.language }}
           config-file: ./.github/codeql/codeql-config.yml
 
-      - name: Install deps
-        run: sudo apt-get install -y libfontconfig1-dev libfreetype-dev libxml2-dev libssl-dev libjpeg-dev libpng-dev libtiff-dev
+    - name: Install deps
+      run: sudo apt-get install -y libfontconfig1-dev libfreetype-dev libxml2-dev libssl-dev libjpeg-dev libpng-dev libtiff-dev
 
-      - name: Configure CMake
-        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+    - name: Configure CMake
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
 
-      - name: Build
-        run: cmake --build ${{github.workspace}}/build
+    - name: Build
+      run: cmake --build ${{github.workspace}}/build
 
-      - name: Test
-        working-directory: ${{github.workspace}}/build
-        run: ctest ${{ github.event.inputs.ctestArgs }}
+    - name: Test
+      working-directory: ${{github.workspace}}/build
+      run: ctest ${{ github.event.inputs.ctestArgs }}
 
-      - name: Perform CodeQL Analysis
-        if: ${{ github.event.inputs.runCodeQL }}
-        uses: github/codeql-action/analyze@v4
-        with:
+    - name: Perform CodeQL Analysis
+      if: ${{ github.event.inputs.runCodeQL }}
+      uses: github/codeql-action/analyze@v4
+      with:
           category: "/language:${{matrix.language}}"

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -33,8 +33,8 @@ jobs:
       if: ${{ github.event.inputs.runCodeQL }}
       uses: github/codeql-action/init@v4
       with:
-          languages: ${{ matrix.language }}
-          config-file: ./.github/codeql/codeql-config.yml
+        languages: ${{ matrix.language }}
+        config-file: ./.github/codeql/codeql-config.yml
 
     - name: Install deps
       run: sudo apt-get install -y libfontconfig1-dev libfreetype-dev libxml2-dev libssl-dev libjpeg-dev libpng-dev libtiff-dev
@@ -53,4 +53,4 @@ jobs:
       if: ${{ github.event.inputs.runCodeQL }}
       uses: github/codeql-action/analyze@v4
       with:
-          category: "/language:${{matrix.language}}"
+        category: "/language:${{matrix.language}}"

--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -2,13 +2,13 @@ name: build-mac
 
 on:
   push:
-    branches: [master]
+    branches: [ master ]
   pull_request:
-    branches: [master]
+    branches: [ master ]
   workflow_dispatch:
     inputs:
       ctestArgs:
-        description: "CTest arguments"
+        description: 'CTest arguments'
 
 # NOTE: Don't update other tools with broken linkage with
 # HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK. See https://docs.brew.sh/Manpage#install-options-formulacask-
@@ -21,22 +21,22 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@v6
-        with:
+    - uses: actions/checkout@v6
+      with:
           submodules: true
 
-      - name: Install deps
-        # NOTE: We need to ensure jpeg-turbo is at least version 2.14
-        run: brew update
-          && brew install fontconfig freetype openssl libxml2 jpeg-turbo libpng libtiff
+    - name: Install deps
+      # NOTE: We need to ensure jpeg-turbo is at least version 2.14
+      run: brew update
+           && brew install fontconfig freetype openssl libxml2 jpeg-turbo libpng libtiff
 
-      - name: Configure CMake
-        # NOTE: OpenSSL prefix must be explicitly set
-        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_FIND_FRAMEWORK=NEVER -DCMAKE_PREFIX_PATH=`brew --prefix` -DFontconfig_INCLUDE_DIR=`brew --prefix fontconfig`/include -DOPENSSL_ROOT_DIR=`brew --prefix openssl@3`
+    - name: Configure CMake
+      # NOTE: OpenSSL prefix must be explicitly set
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_FIND_FRAMEWORK=NEVER -DCMAKE_PREFIX_PATH=`brew --prefix` -DFontconfig_INCLUDE_DIR=`brew --prefix fontconfig`/include -DOPENSSL_ROOT_DIR=`brew --prefix openssl@3`
 
-      - name: Build
-        run: cmake --build ${{github.workspace}}/build
+    - name: Build
+      run: cmake --build ${{github.workspace}}/build
 
-      - name: Test
-        working-directory: ${{github.workspace}}/build
-        run: ctest ${{ github.event.inputs.ctestArgs }}
+    - name: Test
+      working-directory: ${{github.workspace}}/build
+      run: ctest ${{ github.event.inputs.ctestArgs }}

--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -2,13 +2,13 @@ name: build-mac
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
   workflow_dispatch:
     inputs:
       ctestArgs:
-        description: 'CTest arguments'
+        description: "CTest arguments"
 
 # NOTE: Don't update other tools with broken linkage with
 # HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK. See https://docs.brew.sh/Manpage#install-options-formulacask-
@@ -21,23 +21,22 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v2
-      with:
+      - uses: actions/checkout@v6
+        with:
           submodules: true
 
-    - name: Install deps
-      # NOTE: We need to ensure jpeg-turbo is at least version 2.14
-      run: brew update
-           && brew install fontconfig freetype openssl libxml2 jpeg-turbo libpng libtiff
+      - name: Install deps
+        # NOTE: We need to ensure jpeg-turbo is at least version 2.14
+        run: brew update
+          && brew install fontconfig freetype openssl libxml2 jpeg-turbo libpng libtiff
 
-    - name: Configure CMake
-      # NOTE: OpenSSL prefix must be explicitly set
-      run:
-        cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_FIND_FRAMEWORK=NEVER -DCMAKE_PREFIX_PATH=`brew --prefix` -DFontconfig_INCLUDE_DIR=`brew --prefix fontconfig`/include -DOPENSSL_ROOT_DIR=`brew --prefix openssl@3` 
+      - name: Configure CMake
+        # NOTE: OpenSSL prefix must be explicitly set
+        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_FIND_FRAMEWORK=NEVER -DCMAKE_PREFIX_PATH=`brew --prefix` -DFontconfig_INCLUDE_DIR=`brew --prefix fontconfig`/include -DOPENSSL_ROOT_DIR=`brew --prefix openssl@3`
 
-    - name: Build
-      run: cmake --build ${{github.workspace}}/build
+      - name: Build
+        run: cmake --build ${{github.workspace}}/build
 
-    - name: Test
-      working-directory: ${{github.workspace}}/build
-      run: ctest ${{ github.event.inputs.ctestArgs }}
+      - name: Test
+        working-directory: ${{github.workspace}}/build
+        run: ctest ${{ github.event.inputs.ctestArgs }}

--- a/.github/workflows/build-win-vcpkg.yml
+++ b/.github/workflows/build-win-vcpkg.yml
@@ -1,14 +1,14 @@
 name: build-win-vcpkg
 
 on:
-#  push:
-#    branches: [ master ]
-#  pull_request:
-#    branches: [ master ]
+  #  push:
+  #    branches: [ master ]
+  #  pull_request:
+  #    branches: [ master ]
   workflow_dispatch:
     inputs:
       ctestArgs:
-        description: 'CTest arguments'
+        description: "CTest arguments"
 
 env:
   BUILD_TYPE: Release
@@ -17,31 +17,31 @@ env:
 
 jobs:
   build:
-    runs-on: windows-2019
+    runs-on: windows-2025
 
     steps:
-    - uses: actions/checkout@v2
-      with:
+      - uses: actions/checkout@v6
+        with:
           submodules: true
 
-    - name: Install deps
-      run: vcpkg install fontconfig freetype libxml2 openssl libjpeg-turbo libpng tiff zlib
+      - name: Install deps
+        run: vcpkg install fontconfig freetype libxml2 openssl libjpeg-turbo libpng tiff zlib
 
-    - name: Configure CMake
-      run: cmake -B ${{github.workspace}}\build -S . -A x64 -DCMAKE_TOOLCHAIN_FILE=C:\vcpkg\scripts\buildsystems\vcpkg.cmake -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+      - name: Configure CMake
+        run: cmake -B ${{github.workspace}}\build -S . -A x64 -DCMAKE_TOOLCHAIN_FILE=C:\vcpkg\scripts\buildsystems\vcpkg.cmake -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
 
-      # NOTE1: The cmake build is forced to be single
-      # configuration (either Debug or Release) but it
-      #  must be specified when running tests on Windows
-      # because of MSVC solution oddities
-      # NOTE2: vcpkg is installed in C:\vcpkg as per Github
-      # documentation, but VCPKG_INSTALLATION_ROOT variable
-      # doesn't seem to be defined
-      # https://github.com/actions/runner-images/blob/main/images/win/Windows2019-Readme.md
+        # NOTE1: The cmake build is forced to be single
+        # configuration (either Debug or Release) but it
+        #  must be specified when running tests on Windows
+        # because of MSVC solution oddities
+        # NOTE2: vcpkg is installed in C:\vcpkg as per Github
+        # documentation, but VCPKG_INSTALLATION_ROOT variable
+        # doesn't seem to be defined
+        # https://github.com/actions/runner-images/blob/main/images/win/Windows2022-Readme.md
 
-    - name: Build
-      run: cmake --build ${{github.workspace}}\build --config ${{env.BUILD_TYPE}}
+      - name: Build
+        run: cmake --build ${{github.workspace}}\build --config ${{env.BUILD_TYPE}}
 
-    - name: Test
-      working-directory: ${{github.workspace}}\build
-      run: ctest ${{ github.event.inputs.ctestArgs }}
+      - name: Test
+        working-directory: ${{github.workspace}}\build
+        run: ctest ${{ github.event.inputs.ctestArgs }}

--- a/.github/workflows/build-win-vcpkg.yml
+++ b/.github/workflows/build-win-vcpkg.yml
@@ -37,7 +37,7 @@ jobs:
       # NOTE2: vcpkg is installed in C:\vcpkg as per Github
       # documentation, but VCPKG_INSTALLATION_ROOT variable
       # doesn't seem to be defined
-      # https://github.com/actions/runner-images/blob/main/images/win/Windows2022-Readme.md
+      # https://github.com/actions/runner-images/blob/main/images/windows/Windows2025-Readme.md
 
     - name: Build
       run: cmake --build ${{github.workspace}}\build --config ${{env.BUILD_TYPE}}

--- a/.github/workflows/build-win-vcpkg.yml
+++ b/.github/workflows/build-win-vcpkg.yml
@@ -1,14 +1,14 @@
 name: build-win-vcpkg
 
 on:
-  #  push:
-  #    branches: [ master ]
-  #  pull_request:
-  #    branches: [ master ]
+#  push:
+#    branches: [ master ]
+#  pull_request:
+#    branches: [ master ]
   workflow_dispatch:
     inputs:
       ctestArgs:
-        description: "CTest arguments"
+        description: 'CTest arguments'
 
 env:
   BUILD_TYPE: Release
@@ -20,28 +20,28 @@ jobs:
     runs-on: windows-2025
 
     steps:
-      - uses: actions/checkout@v6
-        with:
+    - uses: actions/checkout@v6
+      with:
           submodules: true
 
-      - name: Install deps
-        run: vcpkg install fontconfig freetype libxml2 openssl libjpeg-turbo libpng tiff zlib
+    - name: Install deps
+      run: vcpkg install fontconfig freetype libxml2 openssl libjpeg-turbo libpng tiff zlib
 
-      - name: Configure CMake
-        run: cmake -B ${{github.workspace}}\build -S . -A x64 -DCMAKE_TOOLCHAIN_FILE=C:\vcpkg\scripts\buildsystems\vcpkg.cmake -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+    - name: Configure CMake
+      run: cmake -B ${{github.workspace}}\build -S . -A x64 -DCMAKE_TOOLCHAIN_FILE=C:\vcpkg\scripts\buildsystems\vcpkg.cmake -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
 
-        # NOTE1: The cmake build is forced to be single
-        # configuration (either Debug or Release) but it
-        #  must be specified when running tests on Windows
-        # because of MSVC solution oddities
-        # NOTE2: vcpkg is installed in C:\vcpkg as per Github
-        # documentation, but VCPKG_INSTALLATION_ROOT variable
-        # doesn't seem to be defined
-        # https://github.com/actions/runner-images/blob/main/images/win/Windows2022-Readme.md
+      # NOTE1: The cmake build is forced to be single
+      # configuration (either Debug or Release) but it
+      #  must be specified when running tests on Windows
+      # because of MSVC solution oddities
+      # NOTE2: vcpkg is installed in C:\vcpkg as per Github
+      # documentation, but VCPKG_INSTALLATION_ROOT variable
+      # doesn't seem to be defined
+      # https://github.com/actions/runner-images/blob/main/images/win/Windows2022-Readme.md
 
-      - name: Build
-        run: cmake --build ${{github.workspace}}\build --config ${{env.BUILD_TYPE}}
+    - name: Build
+      run: cmake --build ${{github.workspace}}\build --config ${{env.BUILD_TYPE}}
 
-      - name: Test
-        working-directory: ${{github.workspace}}\build
-        run: ctest ${{ github.event.inputs.ctestArgs }}
+    - name: Test
+      working-directory: ${{github.workspace}}\build
+      run: ctest ${{ github.event.inputs.ctestArgs }}

--- a/.github/workflows/build-win.yml
+++ b/.github/workflows/build-win.yml
@@ -2,13 +2,13 @@ name: build-win
 
 on:
   push:
-    branches: [master]
+    branches: [ master ]
   pull_request:
-    branches: [master]
+    branches: [ master ]
   workflow_dispatch:
     inputs:
       ctestArgs:
-        description: "CTest arguments"
+        description: 'CTest arguments'
 
 env:
   BUILD_TYPE: Release
@@ -18,23 +18,23 @@ jobs:
     runs-on: windows-2025
 
     steps:
-      - uses: actions/checkout@v6
-        with:
+    - uses: actions/checkout@v6
+      with:
           submodules: true
 
-      - name: Configure CMake
-        working-directory: .\playground
-        run: cmake -B build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -A x64 -DARCH=Win64
+    - name: Configure CMake
+      working-directory: .\playground
+      run: cmake -B build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -A x64 -DARCH=Win64
 
-        # NOTE: The cmake build is forced to be single
-        # configuration (either Debug or Release) but it
-        #  must be specified when running tests on Windows
-        # because of MSVC solution oddities
+      # NOTE: The cmake build is forced to be single
+      # configuration (either Debug or Release) but it
+      #  must be specified when running tests on Windows
+      # because of MSVC solution oddities
 
-      - name: Build
-        working-directory: .\playground
-        run: cmake --build build --config ${{env.BUILD_TYPE}}
+    - name: Build
+      working-directory: .\playground
+      run: cmake --build build --config ${{env.BUILD_TYPE}}
 
-      - name: Test
-        working-directory: .\playground
-        run: ctest --test-dir build ${{ github.event.inputs.ctestArgs }}
+    - name: Test
+      working-directory: .\playground
+      run: ctest --test-dir build ${{ github.event.inputs.ctestArgs }}

--- a/.github/workflows/build-win.yml
+++ b/.github/workflows/build-win.yml
@@ -2,39 +2,39 @@ name: build-win
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
   workflow_dispatch:
     inputs:
       ctestArgs:
-        description: 'CTest arguments'
+        description: "CTest arguments"
 
 env:
   BUILD_TYPE: Release
 
 jobs:
   build:
-    runs-on: windows-2022
+    runs-on: windows-2025
 
     steps:
-    - uses: actions/checkout@v2
-      with:
+      - uses: actions/checkout@v6
+        with:
           submodules: true
 
-    - name: Configure CMake
-      working-directory: .\playground
-      run: cmake -B build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -A x64 -DARCH=Win64
+      - name: Configure CMake
+        working-directory: .\playground
+        run: cmake -B build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -A x64 -DARCH=Win64
 
-      # NOTE: The cmake build is forced to be single
-      # configuration (either Debug or Release) but it
-      #  must be specified when running tests on Windows
-      # because of MSVC solution oddities
+        # NOTE: The cmake build is forced to be single
+        # configuration (either Debug or Release) but it
+        #  must be specified when running tests on Windows
+        # because of MSVC solution oddities
 
-    - name: Build
-      working-directory: .\playground
-      run: cmake --build build --config ${{env.BUILD_TYPE}}
+      - name: Build
+        working-directory: .\playground
+        run: cmake --build build --config ${{env.BUILD_TYPE}}
 
-    - name: Test
-      working-directory: .\playground
-      run: ctest --test-dir build ${{ github.event.inputs.ctestArgs }}
+      - name: Test
+        working-directory: .\playground
+        run: ctest --test-dir build ${{ github.event.inputs.ctestArgs }}


### PR DESCRIPTION
Hi, yesterday I created a fork of the repo to make a port to Android/iOS. It's still happening in my fork in another branch. I use it to learn more about the codebase as I didn't have much experience with C++ in general.

But when looking at the CI workflows, I think there are rooms for improvements and there are some outdated stuff, so I created the PR.

The PR aims to:

- Update the runner images to latest LTS version.
- Update various action versions to newer stable ones, as Node 20 is going to be deprecated/unsupported.

---

- [x] All the submited contents are fully human supervised and reviewed
- [x] Claim autorship on the whole submited code and documentation, if not specified differently
- [x] Accept to license the library and tools code under the terms
  of the [LGPL 2.0](https://spdx.org/licenses/LGPL-2.0-or-later.html) or later
- [x] Accept to license the library and tools code under the terms
  of the [MPL 2.0](https://spdx.org/licenses/MPL-2.0)
- [x] Accept to license the test code under the terms
  of the [MIT-0](https://spdx.org/licenses/MIT-0.html)
- [x] AI assistants are not listed among co-authors in the commit message
- [x] Read contributions [guidelines](https://github.com/podofo/podofo#contributions)
- [x] Checked coding [style](https://github.com/podofo/podofo/blob/master/CODING-STYLE.md)
- [x] The commits sequence is [clean](https://github.com/podofo/podofo/wiki/Squash-git-history-guide)
 without work in progress/bugged revisions and merge commits

