### PR TITLE
PdfPainter: Fix exception-safety for text drawing and XObject operations

### DIFF
--- a/src/podofo/main/PdfPainter.cpp
+++ b/src/podofo/main/PdfPainter.cpp
@@ -329,20 +329,28 @@ void PdfPainter::DrawText(const string_view& str, double x, double y,
     checkStatus(StatusDefault);
     checkFont();
 
+    // NOTE: Pre-resolve all throwable operations before emitting any stream operators
+    auto& font = *m_StateStack.Current->TextState.Font;
+    auto expStr = this->expandTabs(str);
+    auto encoded = font.GetEncoding().ConvertToEncoded(expStr);
+    tryAddResource(font.GetObject(), PdfResourceType::Font);
+
     vector<array<double, 4>> linesToDraw;
     save();
     PoDoFo::WriteOperator_BT(m_stream);
     writeTextState();
-    drawText(str, x, y,
+    drawText(expStr, x, y,
         (style & PdfDrawTextStyle::Underline) != PdfDrawTextStyle::Regular,
-        (style & PdfDrawTextStyle::StrikeThrough) != PdfDrawTextStyle::Regular, linesToDraw);
+        (style & PdfDrawTextStyle::StrikeThrough) != PdfDrawTextStyle::Regular, linesToDraw,
+        encoded);
     PoDoFo::WriteOperator_ET(m_stream);
     drawLines(linesToDraw);
     restore();
 }
 
 void PdfPainter::drawText(const string_view& str, double x, double y,
-    bool isUnderline, bool isStrikeThrough, vector<array<double, 4>>& linesToDraw)
+    bool isUnderline, bool isStrikeThrough, vector<array<double, 4>>& linesToDraw,
+    string_view encoded)
 {
     auto& textState = m_StateStack.Current->TextState;
     auto& font = *textState.Font;
@@ -374,7 +382,7 @@ void PdfPainter::drawText(const string_view& str, double x, double y,
 
     PoDoFo::WriteOperator_Td(m_stream, x, y);
 
-    PoDoFo::WriteOperator_Tj(m_stream, font.GetEncoding().ConvertToEncoded(str),
+    PoDoFo::WriteOperator_Tj(m_stream, encoded,
         !font.GetEncoding().IsSimpleEncoding());
 }
 
@@ -409,11 +417,17 @@ void PdfPainter::DrawTextAligned(const string_view& str, double x, double y, dou
     checkStatus(StatusDefault | StatusTextObject);
     checkFont();
 
+    // NOTE: Pre-resolve all throwable operations before emitting any stream operators
+    auto& font = *m_StateStack.Current->TextState.Font;
+    auto expStr = this->expandTabs(str);
+    auto encoded = font.GetEncoding().ConvertToEncoded(expStr);
+    tryAddResource(font.GetObject(), PdfResourceType::Font);
+
     save();
     PoDoFo::WriteOperator_BT(m_stream);
     writeTextState();
     vector<array<double, 4>> linesToDraw;
-    drawTextAligned(str, x, y, width, hAlignment, style, linesToDraw);
+    drawTextAligned(expStr, x, y, width, hAlignment, style, linesToDraw, encoded);
     PoDoFo::WriteOperator_ET(m_stream);
     drawLines(linesToDraw);
     restore();
@@ -426,15 +440,24 @@ void PdfPainter::drawMultiLineText(const string_view& str, double x, double y, d
     auto& textState = m_StateStack.Current->TextState;
     auto& font = *textState.Font;
 
+    // NOTE: Pre-resolve all throwable operations before touching the stream
+    vector<string> lines = textState.SplitTextAsLines(str, width, preserveTrailingSpaces);
+    vector<charbuff> encodedLines;
+    encodedLines.reserve(lines.size());
+    for (unsigned i = 0; i < lines.size(); i++)
+    {
+        auto& line = lines[i];
+        encodedLines.push_back(line.empty() ? charbuff{} : font.GetEncoding().ConvertToEncoded(line));
+    }
+
+    tryAddResource(font.GetObject(), PdfResourceType::Font);
+
     this->save();
     if (!skipClip)
         this->SetClipRect(x, y, width, height);
 
-    auto expanded = this->expandTabs(str);
-
     PoDoFo::WriteOperator_BT(m_stream);
     writeTextState();
-    vector<string> lines = m_StateStack.Current->TextState.SplitTextAsLines(str, width, preserveTrailingSpaces);
     double lineGap = font.GetLineSpacing(textState) - font.GetAscent(textState) + font.GetDescent(textState);
     // Do vertical alignment
     switch (vAlignment)
@@ -453,10 +476,10 @@ void PdfPainter::drawMultiLineText(const string_view& str, double x, double y, d
 
     y -= font.GetAscent(textState) + lineGap / 2;
     vector<array<double, 4>> linesToDraw;
-    for (auto& line : lines)
+    for (unsigned i = 0; i < lines.size(); i++)
     {
-        if (line.length() != 0)
-            this->drawTextAligned(line, x, y, width, hAlignment, style, linesToDraw);
+        if (lines[i].length() != 0)
+            this->drawTextAligned(lines[i], x, y, width, hAlignment, style, linesToDraw, encodedLines[i]);
 
         x = 0;
         switch (hAlignment)
@@ -465,10 +488,10 @@ void PdfPainter::drawMultiLineText(const string_view& str, double x, double y, d
             case PdfHorizontalAlignment::Left:
                 break;
             case PdfHorizontalAlignment::Center:
-                x = -(width - textState.Font->GetStringLength(line, textState)) / 2.0;
+                x = -(width - textState.Font->GetStringLength(lines[i], textState)) / 2.0;
                 break;
             case PdfHorizontalAlignment::Right:
-                x = -(width - textState.Font->GetStringLength(line, textState));
+                x = -(width - textState.Font->GetStringLength(lines[i], textState));
                 break;
         }
         y = -font.GetLineSpacing(textState);
@@ -479,7 +502,8 @@ void PdfPainter::drawMultiLineText(const string_view& str, double x, double y, d
 }
 
 void PdfPainter::drawTextAligned(const string_view& str, double x, double y, double width,
-    PdfHorizontalAlignment hAlignment, PdfDrawTextStyle style, vector<array<double, 4>>& linesToDraw)
+    PdfHorizontalAlignment hAlignment, PdfDrawTextStyle style, vector<array<double, 4>>& linesToDraw,
+    string_view encoded)
 {
     auto& textState = m_StateStack.Current->TextState;
     switch (hAlignment)
@@ -498,7 +522,7 @@ void PdfPainter::drawTextAligned(const string_view& str, double x, double y, dou
     this->drawText(str, x, y,
         (style & PdfDrawTextStyle::Underline) != PdfDrawTextStyle::Regular,
         (style & PdfDrawTextStyle::StrikeThrough) != PdfDrawTextStyle::Regular,
-        linesToDraw);
+        linesToDraw, encoded);
 }
 
 void PdfPainter::DrawImage(const PdfImage& obj, double x, double y, double scaleX, double scaleY)
@@ -511,9 +535,11 @@ void PdfPainter::DrawImage(const PdfImage& obj, double x, double y, double scale
 void PdfPainter::DrawXObject(const PdfXObject& obj, double x, double y, double scaleX, double scaleY)
 {
     checkStream();
+    // NOTE: Pre-resolve throwable operations before emitting any stream operators
+    auto resName = tryAddResource(obj.GetObject(), PdfResourceType::XObject);
     PoDoFo::WriteOperator_q(m_stream);
     PoDoFo::WriteOperator_cm(m_stream, scaleX, 0, 0, scaleY, x, y);
-    PoDoFo::WriteOperator_Do(m_stream, tryAddResource(obj.GetObject(), PdfResourceType::XObject));
+    PoDoFo::WriteOperator_Do(m_stream, resName);
     PoDoFo::WriteOperator_Q(m_stream);
 }
 
@@ -629,6 +655,10 @@ void PdfPainter::BeginText()
 {
     checkStream();
     checkStatus(StatusDefault | StatusTextObject);
+    // NOTE: Pre-resolve throwable operations before emitting any stream operators
+    auto& textState = m_StateStack.Current->TextState;
+    if (textState.Font != nullptr)
+        tryAddResource(textState.Font->GetObject(), PdfResourceType::Font);
     PoDoFo::WriteOperator_BT(m_stream);
     enterTextObject();
     writeTextState();
@@ -648,7 +678,9 @@ void PdfPainter::AddText(const string_view& str)
     checkFont();
     auto expStr = this->expandTabs(str);
     auto& font = *m_StateStack.Current->TextState.Font;
-    PoDoFo::WriteOperator_Tj(m_stream, font.GetEncoding().ConvertToEncoded(expStr),
+    // NOTE: Pre-resolve throwable operations before emitting any stream operators
+    auto encoded = font.GetEncoding().ConvertToEncoded(expStr);
+    PoDoFo::WriteOperator_Tj(m_stream, encoded,
         !font.GetEncoding().IsSimpleEncoding());
 }
 

--- a/src/podofo/main/PdfPainter.h
+++ b/src/podofo/main/PdfPainter.h
@@ -676,10 +676,12 @@ private:
 
 private:
     void drawTextAligned(const std::string_view& str, double x, double y, double width,
-        PdfHorizontalAlignment hAlignment, PdfDrawTextStyle style, std::vector<std::array<double, 4>>& linesToDraw);
+        PdfHorizontalAlignment hAlignment, PdfDrawTextStyle style, std::vector<std::array<double, 4>>& linesToDraw,
+        std::string_view encoded);
 
     void drawText(const std::string_view& str, double x, double y,
-        bool isUnderline, bool isStrikeThrough, std::vector<std::array<double, 4>>& linesToDraw);
+        bool isUnderline, bool isStrikeThrough, std::vector<std::array<double, 4>>& linesToDraw,
+        std::string_view encoded);
 
     void drawMultiLineText(const std::string_view& str, double x, double y, double width, double height,
         PdfHorizontalAlignment hAlignment, PdfVerticalAlignment vAlignment, bool skipClip, bool preserveTrailingSpaces,

--- a/test/unit/PageTest.cpp
+++ b/test/unit/PageTest.cpp
@@ -87,21 +87,19 @@ static void testFillFromPage(const Rect& mediaBox, int rotation,
     auto xobj = dstDoc.CreateXObjectForm(Rect());
     xobj->FillFromPage(srcPage);
 
-    const PdfArray* bboxArr;
-    REQUIRE(xobj->GetDictionary().TryFindKeyAs("BBox", bboxArr));
-    REQUIRE((*bboxArr)[0].GetReal() == Catch::Detail::Approx(expected.bboxX1));
-    REQUIRE((*bboxArr)[1].GetReal() == Catch::Detail::Approx(expected.bboxY1));
-    REQUIRE((*bboxArr)[2].GetReal() == Catch::Detail::Approx(expected.bboxX2));
-    REQUIRE((*bboxArr)[3].GetReal() == Catch::Detail::Approx(expected.bboxY2));
+    auto& bboxArr = xobj->GetDictionary().FindKeyAs<PdfArray>("BBox");
+    REQUIRE(bboxArr[0].GetReal() == Catch::Detail::Approx(expected.bboxX1));
+    REQUIRE(bboxArr[1].GetReal() == Catch::Detail::Approx(expected.bboxY1));
+    REQUIRE(bboxArr[2].GetReal() == Catch::Detail::Approx(expected.bboxX2));
+    REQUIRE(bboxArr[3].GetReal() == Catch::Detail::Approx(expected.bboxY2));
 
-    const PdfArray* matrixArr;
-    REQUIRE(xobj->GetDictionary().TryFindKeyAs("Matrix", matrixArr));
-    REQUIRE((*matrixArr)[0].GetReal() == Catch::Detail::Approx(expected.matA).margin(1e-10));
-    REQUIRE((*matrixArr)[1].GetReal() == Catch::Detail::Approx(expected.matB).margin(1e-10));
-    REQUIRE((*matrixArr)[2].GetReal() == Catch::Detail::Approx(expected.matC).margin(1e-10));
-    REQUIRE((*matrixArr)[3].GetReal() == Catch::Detail::Approx(expected.matD).margin(1e-10));
-    REQUIRE((*matrixArr)[4].GetReal() == Catch::Detail::Approx(expected.matE).margin(1e-6));
-    REQUIRE((*matrixArr)[5].GetReal() == Catch::Detail::Approx(expected.matF).margin(1e-6));
+    auto& matrixArr = xobj->GetDictionary().FindKeyAs<PdfArray>("Matrix");
+    REQUIRE(matrixArr[0].GetReal() == Catch::Detail::Approx(expected.matA).margin(1e-10));
+    REQUIRE(matrixArr[1].GetReal() == Catch::Detail::Approx(expected.matB).margin(1e-10));
+    REQUIRE(matrixArr[2].GetReal() == Catch::Detail::Approx(expected.matC).margin(1e-10));
+    REQUIRE(matrixArr[3].GetReal() == Catch::Detail::Approx(expected.matD).margin(1e-10));
+    REQUIRE(matrixArr[4].GetReal() == Catch::Detail::Approx(expected.matE).margin(1e-6));
+    REQUIRE(matrixArr[5].GetReal() == Catch::Detail::Approx(expected.matF).margin(1e-6));
 }
 
 TEST_CASE("FillFromPage rotation at origin", "[PdfXObjectForm]")

--- a/test/unit/PainterTest.cpp
+++ b/test/unit/PainterTest.cpp
@@ -685,6 +685,158 @@ TEST_CASE("TestDrawTextMultipleTimes")
         REQUIRE((!data.HasErrors() && !data.HasWarnings()));
 }
 
+// Helper: count non-overlapping occurrences of a substring
+static size_t countOccurrences(const string& haystack, const string& needle)
+{
+    size_t count = 0;
+    size_t pos = 0;
+    while ((pos = haystack.find(needle, pos)) != string::npos)
+    {
+        count++;
+        pos += needle.length();
+    }
+    return count;
+}
+
+// DrawText with unencodable characters must throw without orphaning BT/q
+// in the stream. Before the fix, ConvertToEncoded() was called after BT was
+// already written, leaving the content stream permanently corrupted.
+TEST_CASE("DrawTextExceptionSafety_StreamClean")
+{
+    PdfMemDocument doc;
+    auto& page = doc.GetPages().CreatePage(PdfPageSize::A4);
+
+    PdfFontCreateParams params;
+    params.Encoding = PdfEncoding(PdfEncodingMapFactory::GetWinAnsiEncodingInstancePtr());
+    auto& font = doc.GetFonts().GetStandard14Font(PdfStandard14FontType::Helvetica, params);
+
+    PdfPainter painter;
+    painter.SetCanvas(page);
+    painter.TextState.SetFont(font, 12);
+
+    // CJK characters are outside WinAnsi — triggers PdfErrorCode::InvalidFontData
+    ASSERT_THROW_WITH_ERROR_CODE(
+        painter.DrawText("Hello \xe4\xb8\x96\xe7\x95\x8c", 100, 500),
+        PdfErrorCode::InvalidFontData);
+
+    painter.FinishDrawing();
+    auto out = getContents(page);
+
+    // Stream must be clean: only the FinishDrawing q/Q wrapper, no orphan BT or inner q
+    REQUIRE(out == "q\nQ\n"sv);
+}
+
+// After a failed DrawText, a subsequent valid DrawText must produce a well-formed
+// content stream. Before the fix, the orphaned BT from the first call would nest
+// inside the second call's BT/ET block, producing invalid PDF.
+TEST_CASE("DrawTextExceptionSafety_SubsequentDrawSucceeds")
+{
+    PdfMemDocument doc;
+    auto& page = doc.GetPages().CreatePage(PdfPageSize::A4);
+
+    PdfFontCreateParams params;
+    params.Encoding = PdfEncoding(PdfEncodingMapFactory::GetWinAnsiEncodingInstancePtr());
+    auto& font = doc.GetFonts().GetStandard14Font(PdfStandard14FontType::Helvetica, params);
+
+    PdfPainter painter;
+    painter.SetCanvas(page);
+    painter.TextState.SetFont(font, 12);
+
+    try
+    {
+        painter.DrawText("Hello \xe4\xb8\x96\xe7\x95\x8c", 100, 500);
+    }
+    catch (const PdfError&) { }
+
+    REQUIRE_NOTHROW(painter.DrawText("Hello", 100, 500));
+    painter.FinishDrawing();
+    auto out = getContents(page);
+
+    // Every BT must have a matching ET — no orphans
+    REQUIRE(countOccurrences(out, "BT") == countOccurrences(out, "ET"));
+    REQUIRE(countOccurrences(out, "BT") == 1);
+}
+
+// DrawTextAligned with unencodable characters must not corrupt the stream
+TEST_CASE("DrawTextAlignedExceptionSafety_StreamClean")
+{
+    PdfMemDocument doc;
+    auto& page = doc.GetPages().CreatePage(PdfPageSize::A4);
+
+    PdfFontCreateParams params;
+    params.Encoding = PdfEncoding(PdfEncodingMapFactory::GetWinAnsiEncodingInstancePtr());
+    auto& font = doc.GetFonts().GetStandard14Font(PdfStandard14FontType::Helvetica, params);
+
+    PdfPainter painter;
+    painter.SetCanvas(page);
+    painter.TextState.SetFont(font, 12);
+
+    ASSERT_THROW_WITH_ERROR_CODE(
+        painter.DrawTextAligned("Hello \xe4\xb8\x96\xe7\x95\x8c", 100, 500, 200,
+            PdfHorizontalAlignment::Left),
+        PdfErrorCode::InvalidFontData);
+
+    painter.FinishDrawing();
+    auto out = getContents(page);
+    REQUIRE(out == "q\nQ\n"sv);
+}
+
+// DrawTextMultiLine with unencodable characters must not corrupt the stream
+TEST_CASE("DrawTextMultiLineExceptionSafety_StreamClean")
+{
+    PdfMemDocument doc;
+    auto& page = doc.GetPages().CreatePage(PdfPageSize::A4);
+
+    PdfFontCreateParams params;
+    params.Encoding = PdfEncoding(PdfEncodingMapFactory::GetWinAnsiEncodingInstancePtr());
+    auto& font = doc.GetFonts().GetStandard14Font(PdfStandard14FontType::Helvetica, params);
+
+    PdfPainter painter;
+    painter.SetCanvas(page);
+    painter.TextState.SetFont(font, 12);
+
+    ASSERT_THROW_WITH_ERROR_CODE(
+        painter.DrawTextMultiLine("Hello \xe4\xb8\x96\xe7\x95\x8c", 100, 500, 200, 100),
+        PdfErrorCode::InvalidFontData);
+
+    painter.FinishDrawing();
+    auto out = getContents(page);
+    REQUIRE(out == "q\nQ\n"sv);
+}
+
+// TextObject.AddText with unencodable characters must not write partial operators
+// to the stream. The BT block remains open (user-managed), and a subsequent valid
+// AddText must succeed.
+TEST_CASE("TextObjectAddTextExceptionSafety_Usable")
+{
+    PdfMemDocument doc;
+    auto& page = doc.GetPages().CreatePage(PdfPageSize::A4);
+
+    PdfFontCreateParams params;
+    params.Encoding = PdfEncoding(PdfEncodingMapFactory::GetWinAnsiEncodingInstancePtr());
+    auto& font = doc.GetFonts().GetStandard14Font(PdfStandard14FontType::Helvetica, params);
+
+    PdfPainter painter;
+    painter.SetCanvas(page);
+    painter.TextState.SetFont(font, 12);
+    painter.TextObject.Begin();
+    painter.TextObject.MoveTo(100, 500);
+
+    ASSERT_THROW_WITH_ERROR_CODE(
+        painter.TextObject.AddText("Hello \xe4\xb8\x96\xe7\x95\x8c"),
+        PdfErrorCode::InvalidFontData);
+
+    // After the throw, the BT is still open — user must call End() to close it.
+    // A subsequent valid AddText should succeed without corrupting the stream.
+    REQUIRE_NOTHROW(painter.TextObject.AddText("Hello"));
+    painter.TextObject.End();
+    painter.FinishDrawing();
+    auto out = getContents(page);
+
+    REQUIRE(countOccurrences(out, "BT") == countOccurrences(out, "ET"));
+    REQUIRE(out.find("Hello") != string::npos);
+}
+
 static void drawSample(PdfPainter& painter)
 {
     painter.DrawCircle(100, 500, 20, PdfPathDrawMode::Fill);


### PR DESCRIPTION
## Summary

`DrawText()`, `DrawTextAligned()`, `DrawTextMultiLine()`, and `DrawXObject()` emit stream operators (`BT`, `q`, `cm`) **before** calling operations that can throw (`ConvertToEncoded()`, `tryAddResource()`). Since PDF content streams are append-only, an exception leaves orphan operators that permanently corrupt all subsequent content on the page.

This PR pre-resolves all throwable operations (text encoding and resource registration) before emitting any stream operators. If they throw, the content stream remains untouched.

Addresses #336

## Changes

**Methods fixed:**
- `DrawText()` / `DrawTextAligned()`: pre-encode text and pre-register font resource before `save()`/`BT`
- `drawMultiLineText()`: pre-encode all split lines and pre-register font before `save()`/`BT`
- `drawText()` / `drawTextAligned()` (private): accept pre-encoded `charbuff` parameter instead of encoding internally
- `DrawXObject()`: pre-register XObject resource before `q`/`cm`
- `BeginText()`: pre-register font resource before `BT` (warms cache so `writeTextState()` → `setFont()` → `tryAddResource()` cannot throw inside the text object)
- `AddText()`: pre-encode text before writing `Tj` operator

Also fixed: on master, `DrawText` passed the raw string (with literal tabs) to `ConvertToEncoded()` while using the expanded string for line-length calculations. The pre-encoding now correctly encodes the tab-expanded string.

## Tests

Five new exception-safety tests in `PainterTest.cpp`:

| Test | Verifies |
|------|----------|
| `DrawTextExceptionSafety_StreamClean` | Failed `DrawText` leaves stream empty (no orphan `BT`/`q`) |
| `DrawTextExceptionSafety_SubsequentDrawSucceeds` | Valid `DrawText` after a failed one produces well-formed output with matched `BT`/`ET` |
| `DrawTextAlignedExceptionSafety_StreamClean` | Same stream-clean guarantee for `DrawTextAligned` |
| `DrawTextMultiLineExceptionSafety_StreamClean` | Same stream-clean guarantee for `DrawTextMultiLine` |
| `TextObjectAddTextExceptionSafety_Usable` | Failed `AddText` inside open `BT` block doesn't corrupt the stream; subsequent `AddText` succeeds |

All 211 tests pass on macOS (Apple Silicon).

---

- [x] All the submited contents are fully human supervised and reviewed
- [x] Claim autorship on the whole submited code and documentation, if not specified differently
- [x] Accept to license the library and tools code under the terms of the [LGPL 2.0](https://spdx.org/licenses/LGPL-2.0-or-later.html) or later
- [x] Accept to license the library and tools code under the terms of the [MPL 2.0](https://spdx.org/licenses/MPL-2.0)
- [x] Accept to license the test code under the terms of the [MIT-0](https://spdx.org/licenses/MIT-0.html)
- [x] AI assistants are not listed among co-authors in the commit message
- [x] Read contributions [guidelines](https://github.com/podofo/podofo#contributions)
- [x] Checked coding [style](https://github.com/podofo/podofo/blob/master/CODING-STYLE.md)
- [x] The commits sequence is [clean](https://github.com/podofo/podofo/wiki/Squash-git-history-guide) without work in progress/bugged revisions and merge commits