### PR TITLE
FillXObjectFromPage: Copy /Group dictionary to preserve transparency compositing

### DIFF
--- a/src/podofo/main/PdfDocument.cpp
+++ b/src/podofo/main/PdfDocument.cpp
@@ -378,6 +378,10 @@ Rect PdfDocument::FillXObjectFromPage(PdfXObjectForm& xobj, const PdfPage& page,
     if (pageObj.IsDictionary() && pageObj.GetDictionary().HasKey("Resources"))
         xobj.GetDictionary().AddKey("Resources"_n, *pageObj.GetDictionary().GetKey("Resources"));
 
+    // preserve transparency group so compositing matches the source page
+    if (pageObj.IsDictionary() && pageObj.GetDictionary().HasKey("Group"))
+        xobj.GetDictionary().AddKey("Group"_n, *pageObj.GetDictionary().GetKey("Group"));
+
     // copy top-level content from external doc to x-object
     if (pageObj.IsDictionary() && pageObj.GetDictionary().HasKey("Contents"))
     {

--- a/test/unit/PageTest.cpp
+++ b/test/unit/PageTest.cpp
@@ -85,3 +85,40 @@ TEST_CASE("TestFlattening")
         REQUIRE(child.GetDictionary().MustGetKey("Parent").GetReference() == pageRootRef);
     }
 }
+
+TEST_CASE("TestFillFromPageCopiesTransparencyGroup")
+{
+    // FillFromPage must propagate /Group so compositing (isolated/knockout
+    // flags, color space) matches the source page — see GitHub issue #337
+    PdfMemDocument sourceDoc;
+    auto& sourcePage = sourceDoc.GetPages().CreatePage(PdfPageSize::A4);
+
+    PdfDictionary groupDict;
+    groupDict.AddKey("Type"_n, PdfName("Group"));
+    groupDict.AddKey("S"_n, PdfName("Transparency"));
+    groupDict.AddKey("I"_n, PdfObject(true));
+    groupDict.AddKey("K"_n, PdfObject(false));
+    sourcePage.GetDictionary().AddKey("Group"_n, groupDict);
+
+    PdfMemDocument destDoc;
+    auto xobj = destDoc.CreateXObjectForm(sourcePage.GetMediaBox());
+    xobj->FillFromPage(sourcePage);
+
+    auto* copiedGroup = xobj->GetDictionary().FindKey("Group");
+    REQUIRE(copiedGroup != nullptr);
+    REQUIRE(copiedGroup->GetDictionary().GetKey("S")->GetName() == "Transparency");
+    REQUIRE(copiedGroup->GetDictionary().GetKey("I")->GetBool() == true);
+    REQUIRE(copiedGroup->GetDictionary().GetKey("K")->GetBool() == false);
+}
+
+TEST_CASE("TestFillFromPageWithoutGroupDoesNotCreateOne")
+{
+    PdfMemDocument sourceDoc;
+    auto& sourcePage = sourceDoc.GetPages().CreatePage(PdfPageSize::A4);
+
+    PdfMemDocument destDoc;
+    auto xobj = destDoc.CreateXObjectForm(sourcePage.GetMediaBox());
+    xobj->FillFromPage(sourcePage);
+
+    REQUIRE(xobj->GetDictionary().FindKey("Group") == nullptr);
+}


### PR DESCRIPTION
## Summary

`FillXObjectFromPage()` copies `/Resources` and content streams from a source page into a Form XObject, but silently drops the `/Group` dictionary. When a source page declares a transparency group (ISO 32000-1 §11.6.6) — common in Illustrator, InDesign, and Photoshop output — the resulting XObject renders without the group's compositing properties (isolated/knockout flags, color space).

This adds a parallel copy block for `/Group` after the existing `/Resources` copy, using the same pattern. The `pageObj` (post-append copy with remapped references) is used, so indirect references inside `/Group` (e.g., ICC profiles) are already correct for the destination document.

### Changes

- **`src/podofo/main/PdfDocument.cpp`**: Copy `/Group` dictionary from source page to Form XObject in `FillXObjectFromPage()`
- **`test/unit/PageTest.cpp`**: Two new tests — verify `/Group` is preserved when present, and not created when absent

Closes #337

## Checklist

- [x] All the submited contents are fully human supervised and reviewed
- [x] Claim autorship on the whole submited code and documentation, if not specified differently
- [x] Accept to license the library and tools code under the terms
  of the [LGPL 2.0](https://spdx.org/licenses/LGPL-2.0-or-later.html) or later
- [x] Accept to license the library and tools code under the terms
  of the [MPL 2.0](https://spdx.org/licenses/MPL-2.0)
- [x] Accept to license the test code under the terms
  of the [MIT-0](https://spdx.org/licenses/MIT-0.html)
- [x] AI assistants are not listed among co-authors in the commit message
- [x] Read contributions [guidelines](https://github.com/podofo/podofo#contributions)
- [x] Checked coding [style](https://github.com/podofo/podofo/blob/master/CODING-STYLE.md)
- [x] The commits sequence is [clean](https://github.com/podofo/podofo/wiki/Squash-git-history-guide) without work in progress/bugged revisions and merge commits