### PR TITLE
FillXObjectFromPage: Copy /Group dictionary to preserve transparency compositing

### DIFF
--- a/src/podofo/main/PdfDocument.cpp
+++ b/src/podofo/main/PdfDocument.cpp
@@ -378,6 +378,15 @@ Rect PdfDocument::FillXObjectFromPage(PdfXObjectForm& xobj, const PdfPage& page,
     if (pageObj.IsDictionary() && pageObj.GetDictionary().HasKey("Resources"))
         xobj.GetDictionary().AddKey("Resources"_n, *pageObj.GetDictionary().GetKey("Resources"));
 
+    // without /Group the viewer resets to default compositing, dropping the
+    // page's isolated/knockout flags and color space (ISO 32000-1 §11.6.6)
+    if (pageObj.IsDictionary())
+    {
+        auto* groupObj = pageObj.GetDictionary().GetKey("Group");
+        if (groupObj != nullptr)
+            xobj.GetDictionary().AddKey("Group"_n, *groupObj);
+    }
+
     // copy top-level content from external doc to x-object
     if (pageObj.IsDictionary() && pageObj.GetDictionary().HasKey("Contents"))
     {

--- a/test/unit/PageTest.cpp
+++ b/test/unit/PageTest.cpp
@@ -85,3 +85,75 @@ TEST_CASE("TestFlattening")
         REQUIRE(child.GetDictionary().MustGetKey("Parent").GetReference() == pageRootRef);
     }
 }
+
+TEST_CASE("TestFillFromPageCopiesTransparencyGroup")
+{
+    // Without the fix, FillFromPage dropped /Group, causing viewers to reset
+    // compositing to defaults and ignore isolation/knockout flags (issue #337)
+    PdfMemDocument sourceDoc;
+    auto& sourcePage = sourceDoc.GetPages().CreatePage(PdfPageSize::A4);
+
+    PdfDictionary groupDict;
+    groupDict.AddKey("Type"_n, PdfName("Group"));
+    groupDict.AddKey("S"_n, PdfName("Transparency"));
+    groupDict.AddKey("I"_n, PdfObject(true));
+    groupDict.AddKey("K"_n, PdfObject(false));
+    groupDict.AddKey("CS"_n, PdfName("DeviceRGB"));
+    sourcePage.GetDictionary().AddKey("Group"_n, groupDict);
+
+    PdfMemDocument destDoc;
+    auto xobj = destDoc.CreateXObjectForm(sourcePage.GetMediaBox());
+    xobj->FillFromPage(sourcePage);
+
+    auto* copiedGroup = xobj->GetDictionary().FindKey("Group");
+    REQUIRE(copiedGroup != nullptr);
+    REQUIRE(copiedGroup->GetDictionary().GetKey("S")->GetName() == "Transparency");
+    REQUIRE(copiedGroup->GetDictionary().GetKey("I")->GetBool() == true);
+    REQUIRE(copiedGroup->GetDictionary().GetKey("K")->GetBool() == false);
+    REQUIRE(copiedGroup->GetDictionary().GetKey("CS")->GetName() == "DeviceRGB");
+}
+
+TEST_CASE("TestFillFromPageCopiesGroupSameDocument")
+{
+    // The same-document path skips object remapping, so it exercises a
+    // different branch in FillXObjectFromPage than the cross-document test
+    PdfMemDocument doc;
+    auto& page = doc.GetPages().CreatePage(PdfPageSize::A4);
+
+    PdfDictionary groupDict;
+    groupDict.AddKey("Type"_n, PdfName("Group"));
+    groupDict.AddKey("S"_n, PdfName("Transparency"));
+    groupDict.AddKey("CS"_n, PdfName("DeviceCMYK"));
+    page.GetDictionary().AddKey("Group"_n, groupDict);
+
+    auto xobj = doc.CreateXObjectForm(page.GetMediaBox());
+    xobj->FillFromPage(page);
+
+    auto* copiedGroup = xobj->GetDictionary().FindKey("Group");
+    REQUIRE(copiedGroup != nullptr);
+    REQUIRE(copiedGroup->GetDictionary().GetKey("S")->GetName() == "Transparency");
+    REQUIRE(copiedGroup->GetDictionary().GetKey("CS")->GetName() == "DeviceCMYK");
+}
+
+TEST_CASE("TestFillFromPageWithoutGroupDoesNotCreateOne")
+{
+    PdfMemDocument sourceDoc;
+    auto& sourcePage = sourceDoc.GetPages().CreatePage(PdfPageSize::A4);
+
+    PdfMemDocument destDoc;
+    auto xobj = destDoc.CreateXObjectForm(sourcePage.GetMediaBox());
+    xobj->FillFromPage(sourcePage);
+
+    REQUIRE(xobj->GetDictionary().FindKey("Group") == nullptr);
+}
+
+TEST_CASE("TestFillFromPageWithoutGroupSameDocument")
+{
+    PdfMemDocument doc;
+    auto& page = doc.GetPages().CreatePage(PdfPageSize::A4);
+
+    auto xobj = doc.CreateXObjectForm(page.GetMediaBox());
+    xobj->FillFromPage(page);
+
+    REQUIRE(xobj->GetDictionary().FindKey("Group") == nullptr);
+}


### PR DESCRIPTION
## Summary

`FillXObjectFromPage` copies `/Resources` and `/Contents` from the source page to the XObject form, but omitted the `/Group` dictionary. Without `/Group`, PDF viewers reset to the default compositing model, dropping the page's isolated/knockout flags and color space (ISO 32000-1 §11.6.6). This caused transparency to render incorrectly when converting pages to XObjects.

**Fix:** Copy the `/Group` entry when present, using a single `GetKey` lookup with nullptr check (avoids the `HasKey`+`GetKey` double-lookup pattern used by the adjacent blocks).

**Tests:** Four test cases covering the full 2×2 matrix:
- Cross-document with /Group (full dict: Type, S, I, K, CS)
- Same-document with /Group (minimal dict: Type, S, CS)
- Cross-document without /Group (negative)
- Same-document without /Group (negative)

Closes #337

## Checklist

- [x] All the submited contents are fully human supervised and reviewed
- [x] Claim autorship on the whole submited code and documentation, if not specified differently
- [x] Accept to license the library and tools code under the terms
  of the [LGPL 2.0](https://spdx.org/licenses/LGPL-2.0-or-later.html) or later
- [x] Accept to license the library and tools code under the terms
  of the [MPL 2.0](https://spdx.org/licenses/MPL-2.0)
- [x] Accept to license the test code under the terms
  of the [MIT-0](https://spdx.org/licenses/MIT-0.html)
- [x] AI assistants are not listed among co-authors in the commit message
- [x] Read contributions [guidelines](https://github.com/podofo/podofo#contributions)
- [x] Checked coding [style](https://github.com/podofo/podofo/blob/master/CODING-STYLE.md)
- [x] The commits sequence is [clean](https://github.com/podofo/podofo/wiki/Squash-git-history-guide)
 without work in progress/bugged revisions and merge commits