### PR TITLE
Fix PdfField::GetWidget() returning NULL for AcroForm-iterated fields

### DIFF
--- a/src/podofo/main/PdfField.cpp
+++ b/src/podofo/main/PdfField.cpp
@@ -16,6 +16,9 @@
 #include "PdfTextBox.h"
 #include "PdfComboBox.h"
 #include "PdfListBox.h"
+#include "PdfPage.h"
+#include "PdfPageCollection.h"
+#include "PdfAnnotationWidget.h"
 
  // https://en.wikipedia.org/wiki/Escape_character#ASCII_escape_character
 #define ESCAPE_CHARACTER "\033"
@@ -520,8 +523,46 @@ void PdfField::AssertTerminalField() const
     }
 }
 
+PdfAnnotationWidget* PdfField::GetWidget()
+{
+    resolveWidget();
+    return m_Widget;
+}
+
+const PdfAnnotationWidget* PdfField::GetWidget() const
+{
+    const_cast<PdfField&>(*this).resolveWidget();
+    return m_Widget;
+}
+
+void PdfField::resolveWidget()
+{
+    if (m_Widget != nullptr)
+        return;
+
+    auto* subtype = GetDictionary().FindKey("Subtype");
+    if (subtype == nullptr || !subtype->IsName() || subtype->GetName() != "Widget")
+        return;
+
+    auto& pages = GetDocument().GetPages();
+    for (unsigned i = 0; i < pages.GetCount(); i++)
+    {
+        auto& annots = pages.GetPageAt(i).GetAnnotations();
+        for (unsigned j = 0; j < annots.GetCount(); j++)
+        {
+            auto& annot = annots.GetAnnotAt(j);
+            if (&annot.GetObject() == &GetObject())
+            {
+                m_Widget = &static_cast<PdfAnnotationWidget&>(annot);
+                return;
+            }
+        }
+    }
+}
+
 PdfAnnotationWidget& PdfField::MustGetWidget()
 {
+    resolveWidget();
     if (m_Widget == nullptr)
         PODOFO_RAISE_ERROR_INFO(PdfErrorCode::InvalidHandle, "Expected to retrieve a field with a linked widget annotation");
 
@@ -530,6 +571,7 @@ PdfAnnotationWidget& PdfField::MustGetWidget()
 
 const PdfAnnotationWidget& PdfField::MustGetWidget() const
 {
+    const_cast<PdfField&>(*this).resolveWidget();
     if (m_Widget == nullptr)
         PODOFO_RAISE_ERROR_INFO(PdfErrorCode::InvalidHandle, "Expected to retrieve a field with a linked widget annotation");
 

--- a/src/podofo/main/PdfField.h
+++ b/src/podofo/main/PdfField.h
@@ -184,9 +184,9 @@ public:
 public:
     PdfFieldType GetType() const { return m_FieldType; }
 
-    PdfAnnotationWidget* GetWidget() { return m_Widget; }
+    PdfAnnotationWidget* GetWidget();
 
-    const PdfAnnotationWidget* GetWidget() const { return m_Widget; }
+    const PdfAnnotationWidget* GetWidget() const;
 
     PdfAnnotationWidget& MustGetWidget();
 
@@ -276,6 +276,7 @@ private:
     std::shared_ptr<PdfField> GetPtr();
     PdfField* getParentTyped(PdfFieldType type) const;
     std::string_view getFieldTypeDisplayName() const;
+    void resolveWidget();
 
 private:
     PdfAnnotationWidget* m_Widget;

--- a/test/unit/SignatureTest.cpp
+++ b/test/unit/SignatureTest.cpp
@@ -503,3 +503,30 @@ TEST_CASE("TestSignatureCorrupted")
         throw;
     }
 }
+
+TEST_CASE("TestAcroFormSignatureGetWidget")
+{
+    PdfMemDocument doc;
+    auto& page = doc.GetPages().CreatePage(PdfPageSize::A4);
+
+    auto& signature = page.CreateField<PdfSignature>("TestSig", Rect(10, 10, 50, 20));
+
+    REQUIRE(signature.GetWidget() != nullptr);
+
+    auto* form = doc.GetAcroForm();
+    REQUIRE(form != nullptr);
+
+    PdfSignature* foundSig = nullptr;
+    for (auto* field : *form)
+    {
+        if (field->GetType() == PdfFieldType::Signature)
+        {
+            foundSig = static_cast<PdfSignature*>(field);
+            break;
+        }
+    }
+
+    REQUIRE(foundSig != nullptr);
+    REQUIRE(foundSig->GetWidget() != nullptr);
+    REQUIRE(&foundSig->GetWidget()->GetObject() == &signature.GetObject());
+}


### PR DESCRIPTION
When a field is created via page->CreateField<PdfSignature>(), PoDoFo creates two C++ wrapper objects for the same PDF dictionary: one on the PdfAnnotationWidget (with m_Widget set) and one in PdfAcroForm::m_Fields (with m_Widget = nullptr). When iterating fields via AcroForm, GetWidget() returns NULL because the AcroForm copy never had m_Widget linked.

- [x] All the submited contents are fully human supervised and reviewed
- [x] Claim autorship on the whole submited code and documentation, if not specified differently
- [x] Accept to license the library and tools code under the terms
  of the [LGPL 2.0](https://spdx.org/licenses/LGPL-2.0-or-later.html) or later
- [x] Accept to license the library and tools code under the terms
  of the [MPL 2.0](https://spdx.org/licenses/MPL-2.0)
- [x] Accept to license the test code under the terms
  of the [MIT-0](https://spdx.org/licenses/MIT-0.html)
- [x] AI assistants are not listed among co-authors in the commit message
- [x] Read contributions [guidelines](https://github.com/podofo/podofo#contributions)
- [x] Checked coding [style](https://github.com/podofo/podofo/blob/master/CODING-STYLE.md)
- [x] The commits sequence is [clean](https://github.com/podofo/podofo/wiki/Squash-git-history-guide)
 without work in progress/bugged revisions and merge commits