### PR TITLE
Fix PdfRLEFilter::DecodeBlockImpl RunLengthDecode correctness bugs

### DIFF
--- a/src/podofo/private/PdfFiltersImpl.cpp
+++ b/src/podofo/private/PdfFiltersImpl.cpp
@@ -618,7 +618,7 @@ void PdfFlateFilter::EndDecodeImpl()
 #pragma region PdfRLEFilter
 
 PdfRLEFilter::PdfRLEFilter()
-    : m_CodeLen(0)
+    : m_CodeLen(0), m_AwaitingControlByte(true)
 {
 }
 
@@ -630,31 +630,54 @@ void PdfRLEFilter::EncodeBlockImpl(const char*, size_t)
 void PdfRLEFilter::BeginDecodeImpl(const PdfDictionary*)
 {
     m_CodeLen = 0;
+    m_AwaitingControlByte = true;
 }
 
 void PdfRLEFilter::DecodeBlockImpl(const char* buffer, size_t len)
 {
+    // See ISO 32000-2:2020, 7.4.5 "RunLengthDecode filter"
     while (len-- != 0)
     {
-        if (m_CodeLen == 0)
+        if (m_AwaitingControlByte)
         {
-            m_CodeLen = static_cast<int>(*buffer);
+            // Cast through unsigned char, or a control byte >= 128 would
+            // sign-extend to a negative int and be misclassified below
+            m_CodeLen = static_cast<unsigned char>(*buffer);
+            if (m_CodeLen == 128)
+            {
+                // EOD marker
+                break;
+            }
+            else if (m_CodeLen <= 127)
+            {
+                // The next m_CodeLen + 1 (1 to 128) bytes are literal
+                m_CodeLen++;
+                m_AwaitingControlByte = false;
+            }
+            else
+            {
+                // 129 to 255: the next single byte shall be repeated
+                // 257 - m_CodeLen times. Keep the raw value until that
+                // byte arrives, possibly in a later call
+                m_AwaitingControlByte = false;
+            }
         }
-        else if (m_CodeLen == 128)
+        else if (m_CodeLen <= 128)
         {
-            break;
-        }
-        else if (m_CodeLen <= 127)
-        {
+            // Mid literal run: m_CodeLen holds the remaining byte count
             GetStream().Write(buffer, 1);
-            m_CodeLen--;
+            if (--m_CodeLen == 0)
+                m_AwaitingControlByte = true;
         }
-        else if (m_CodeLen >= 129)
+        else
         {
-            m_CodeLen = 257 - m_CodeLen;
-
-            while (m_CodeLen--)
+            // Mid repeat run: this is the single byte to be repeated
+            int repeatCount = 257 - m_CodeLen;
+            for (int i = 0; i < repeatCount; i++)
                 GetStream().Write(buffer, 1);
+
+            m_CodeLen = 0;
+            m_AwaitingControlByte = true;
         }
 
         buffer++;

--- a/src/podofo/private/PdfFiltersImpl.h
+++ b/src/podofo/private/PdfFiltersImpl.h
@@ -143,6 +143,7 @@ public:
 
 private:
     int m_CodeLen;
+    bool m_AwaitingControlByte;
 };
 
 /// The LZW filter.

--- a/test/unit/FilterTest.cpp
+++ b/test/unit/FilterTest.cpp
@@ -30,6 +30,26 @@ TEST_CASE("TestFilters")
     }
 }
 
+// RunLengthDecode can't encode, so it's never exercised by TestFilters above:
+// decode a stream combining a literal run, a repeat run and a single-byte
+// literal run (control byte 0) directly instead
+TEST_CASE("TestRunLengthDecodeFilter")
+{
+    const char input[] = {
+        0x02, 'A', 'B', 'C',
+        static_cast<char>(0xFE), 'Z',
+        0x00, 'Q',
+        static_cast<char>(0x80),
+    };
+
+    unique_ptr<PdfFilter> filter;
+    REQUIRE(PdfFilterFactory::TryCreate(PdfFilterType::RunLengthDecode, filter));
+
+    charbuff decoded;
+    filter->DecodeTo(decoded, bufferview(input, std::size(input)));
+    REQUIRE(decoded == "ABCZZZQ");
+}
+
 void testFilter(PdfFilterType filterType, const bufferview& view)
 {
     charbuff encoded;


### PR DESCRIPTION
## Summary

`PdfRLEFilter::DecodeBlockImpl()` (the `RunLengthDecode` filter decoder, `src/podofo/private/PdfFiltersImpl.cpp`) has three compounding correctness bugs:

1. **Missing `unsigned char` cast**: the control byte is assigned to `m_CodeLen` via `static_cast<int>(*buffer)` with no cast through `unsigned char` first, unlike every other filter in this file (`PdfHexFilter` uses an `unsigned char val`; `PdfAscii85Filter`/`PdfLZWFilter` use `static_cast<unsigned char>`). On platforms where `char` is signed, a control byte >= 128 sign-extends to a negative `int` and is misclassified by the range checks.
2. **Off-by-one literal run**: the literal-copy branch copies `m_CodeLen` bytes instead of the `m_CodeLen + 1` bytes required by ISO 32000-2:2020, 7.4.5, Table 8.
3. **Post-decrement underflow**: the repeat-run loop `while (m_CodeLen--)` leaves `m_CodeLen` at `-1` (not `0`) once the run completes, corrupting decoder state for the rest of the stream.

There's also a structural issue underlying (2): `m_CodeLen == 0` is overloaded to mean both "awaiting a new control byte" and "a control byte of value 0 was just read" (which is a valid 1-byte literal run per the spec), so a control byte of `0` is silently treated as if no run occurred, and its data byte gets misread as a new control byte.

## Fix

- Added an explicit `m_AwaitingControlByte` flag to replace the overloaded `m_CodeLen == 0` state check.
- Cast the control byte through `unsigned char`, matching the sibling filters in this file.
- Fixed the literal-run branch to account for the `+ 1`.
- Replaced the post-decrement `while` loop with a bounded `for` loop, with explicit state reset afterward so `m_CodeLen`/`m_AwaitingControlByte` never end up in an inconsistent state between control codes.

`RunLengthDecode` can't encode (`CanEncode()` returns `false`), so `DecodeBlockImpl()` was never reached by the existing `TestFilters` round-trip test in `test/unit/FilterTest.cpp` -- it calls `EncodeTo()` first and returns early on the resulting `PdfErrorCode::UnsupportedFilter`. Added a `TestRunLengthDecodeFilter` test that calls `DecodeTo()` directly, covering a literal run, a repeat run, a control byte of `0`, and the EOD marker.

## Test plan

- [x] Added `TestRunLengthDecodeFilter` in `test/unit/FilterTest.cpp`, decoding a stream combining a 3-byte literal run, a 3x repeat run, a 1-byte literal run (control byte `0`), and EOD, asserting the exact decoded output.
- [x] Verified the corrected decode logic against 8 hand-built RLE byte sequences in a standalone harness (mirroring the actual function body) covering all three bugs individually and in combination, plus cross-call buffer-boundary splits for both literal and repeat runs -- all pass under both signed-char and unsigned-char build configurations.

## Checklist

- [x] All the submited contents are fully human supervised and reviewed
- [x] Claim autorship on the whole submited code and documentation, if not specified differently
- [x] Accept to license the library and tools code under the terms of the [LGPL 2.0](https://spdx.org/licenses/LGPL-2.0-or-later.html) or later
- [x] Accept to license the library and tools code under the terms of the [MPL 2.0](https://spdx.org/licenses/MPL-2.0)
- [x] Accept to license the test code under the terms of the [MIT-0](https://spdx.org/licenses/MIT-0.html)
- [x] AI assistants are not listed among co-authors in the commit message
- [x] Read contributions guidelines
- [x] Checked coding style
- [x] The commits sequence is clean without work in progress/bugged revisions and merge commits
